### PR TITLE
refactor: push signing responsibility from ProofGateway to treasury

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ The middleware never decodes transactions, checks mempool, broadcasts, or intera
 
 ## Gateways
 
-Gateways are pluggable backends that handle chain-specific settlement. They **can** hold keys and sign transactions — they are separate components from the gatekeeper. Each gateway:
+Gateways are pluggable backends that handle chain-specific settlement. They delegate key management and signing to external providers (e.g. the treasury via `nonce_provider`). Each gateway:
 
 - Builds challenge data (including partial transaction templates)
 - Verifies and settles proofs

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -69,8 +69,7 @@ config.gateways = [
   X402::BSV::PayGateway.new(arc_client: arc),
   X402::BSV::ProofGateway.new(
     nonce_provider: treasury,
-    arc_client: arc,
-    nonce_key: nonce_key
+    arc_client: arc
   )
 ]
 ```

--- a/docs/operations/treasury.md
+++ b/docs/operations/treasury.md
@@ -12,7 +12,7 @@ The treasury creates 1-sat P2PKH outputs locked to the nonce key. Each output be
 
 When the ProofGateway builds a challenge, it requests a nonce from the treasury (via the `nonce_provider` callable). The nonce UTXO details (txid, vout, satoshis, locking_script_hex) are included in the challenge.
 
-In Profile B, the gateway signs the nonce input with `0xC3` and includes the pre-signed template in the challenge.
+In Profile B, the treasury signs the nonce input with `0xC3` and returns the pre-signed template (as `partial_tx` binary) to the gateway. The gateway appends the OP_RETURN and includes the template in the challenge.
 
 ### Spending
 
@@ -51,11 +51,19 @@ The treasury is not on the critical path for settlement — it only participates
 
 ## Current Implementation
 
-The `nonce_provider` is currently a raw callable injected into ProofGateway:
+The `nonce_provider` is a callable injected into ProofGateway. It receives `payee:` and `amount:` kwargs so the treasury can build the template:
 
 ```ruby
-nonce_provider = ->(request) {
+# Profile A — bare UTXO metadata
+nonce_provider = ->(request, payee:, amount:) {
   { txid: "...", vout: 0, satoshis: 1, locking_script_hex: "76a914...88ac" }
+}
+
+# Profile B — treasury builds and signs the template
+nonce_provider = ->(request, payee:, amount:) {
+  tx = build_and_sign_template(payee: payee, amount: amount)
+  { txid: "...", vout: 0, satoshis: 1, locking_script_hex: "76a914...88ac",
+    partial_tx: tx.to_binary }
 }
 ```
 

--- a/docs/process-flow/proof-gateway.md
+++ b/docs/process-flow/proof-gateway.md
@@ -81,7 +81,7 @@ sequenceDiagram
 ## Notes
 
 - **Client broadcasts, not server** — broadcasting is settlement, not authorisation. Keeps the server stateless (per Rui at merkleworks).
-- **Profile B template** — the challenge includes a pre-signed template (`partial_tx_b64`) with the nonce input at index 0 signed with `0xC3`. The client extends it by appending funding inputs.
+- **Profile B template** — the treasury (via `nonce_provider`) builds and signs the template. The gateway appends the OP_RETURN and includes it in the challenge as `partial_tx_b64`. The nonce input at index 0 is signed with `0xC3`. The client extends it by appending funding inputs.
 - **0xC3 sighash** — `SIGHASH_SINGLE | ANYONECANPAY | FORKID` commits to output 0 (payment) while allowing additional inputs and outputs. See [architecture.md](../architecture.md#why-0xc3-for-the-nonce-signature).
 - **Fee delegation is optional** — shown as `opt` in the diagram. Most clients can fund their own fees (1-50 sats). The delegator adds fee inputs and signs only those.
 - **Client signs with 0xC1** — `SIGHASH_ALL | ANYONECANPAY | FORKID` on funding inputs. Commits to all outputs but allows the delegator to append fee inputs.

--- a/docs/schemes/bsv-proof.md
+++ b/docs/schemes/bsv-proof.md
@@ -11,21 +11,23 @@ Client broadcasts, server checks mempool. Proof-of-payment model. Nonce-bound wi
 
 ## Profiles
 
-### Profile A (no nonce key)
+### Profile A (no partial template)
 
 The challenge includes nonce UTXO metadata only. The client must construct the entire transaction including the nonce input. No cryptographic proof of nonce provenance.
 
 Suitable for deployments using an external treasury service that returns bare UTXO references.
 
-### Profile B (with nonce key) — recommended
+### Profile B (treasury-signed template) — recommended
 
-The gateway holds a nonce key and produces a **pre-signed template**:
+The **treasury** (via the `nonce_provider` callable) builds and signs a partial template. The gateway receives it and appends the OP_RETURN request binding:
 
 - Input 0: nonce UTXO, signed with `SIGHASH_SINGLE | ANYONECANPAY | FORKID` (`0xC3`)
-- Output 0: payment (committed by the signature)
-- Output 1: OP_RETURN binding (appendable)
+- Output 0: payment (committed by the treasury's signature)
+- Output 1: OP_RETURN binding (appended by the gateway after receiving the template)
 
-The client extends the template by adding funding inputs. The `0xC3` signature proves the server issued the nonce — this is the provenance guarantee.
+The gateway never holds a private key. Profile B is detected from the presence of `partial_tx` in the provider response.
+
+The client extends the template by adding funding inputs. The `0xC3` signature proves the treasury issued the nonce — this is the provenance guarantee.
 
 The template is included in the challenge as `partial_tx_b64` (base64-encoded), excluded from the canonical challenge hash (merkleworks spec compliance).
 
@@ -79,7 +81,29 @@ Per Rui at merkleworks: broadcasting is settlement, not authorisation. If the se
 
 See [operations/treasury.md](../operations/treasury.md) for nonce lifecycle.
 
+## Nonce Provider Interface
+
+The `nonce_provider` is a callable that receives `(rack_request, payee:, amount:)` and returns a hash:
+
+```ruby
+# Profile A — bare UTXO metadata
+provider = ->(request, payee:, amount:) {
+  { txid: "...", vout: 0, satoshis: 1, locking_script_hex: "76a914...88ac" }
+}
+
+# Profile B — includes pre-signed partial template
+provider = ->(request, payee:, amount:) {
+  tx = build_and_sign_template(payee: payee, amount: amount)
+  { txid: "...", vout: 0, satoshis: 1, locking_script_hex: "76a914...88ac",
+    partial_tx: tx.to_binary }
+}
+```
+
+The presence of `:partial_tx` in the response triggers Profile B behaviour. The gateway appends the OP_RETURN after deserialising the template.
+
 ## Infrastructure Required
 
-- **Treasury**: mints nonce UTXOs, holds the nonce key, signs templates (Profile B)
+Trust boundary: `[(X)+(B)] <-> [(T)]` — the server (x402-rack + BSV gateway) never holds keys; the treasury is a separate trust domain.
+
+- **Treasury** (`nonce_provider`): mints nonce UTXOs, holds keys, signs templates (Profile B)
 - **ARC**: mempool queries (`status(txid)`)

--- a/docs/security.md
+++ b/docs/security.md
@@ -48,7 +48,7 @@ The `0xC3` signature on input 0 proves the server issued the nonce. At settlemen
 
 ### Nonce Key Validation
 
-At challenge time (template signing), the gateway validates that the nonce key's public key hash matches the nonce UTXO's P2PKH locking script. Catches misconfiguration before producing an invalid template.
+Key validation is the treasury's responsibility. The gateway never holds a private key — the `nonce_provider` callable builds and signs the template. Misconfiguration (key/UTXO mismatch) is caught at settlement time when `verify_input(0)` fails.
 
 ### Payee Verification
 

--- a/lib/x402/bsv/proof_gateway.rb
+++ b/lib/x402/bsv/proof_gateway.rb
@@ -17,24 +17,22 @@ module X402
     # Proof:     X402-Proof (echoed challenge hash + rawtx + txid)
     #
     # Supports two modes:
-    # - Profile A (no nonce_key): challenge includes nonce UTXO metadata only
-    # - Profile B (with nonce_key): challenge includes pre-signed template with
-    #   nonce input at index 0 signed with 0xC3
+    # - Profile A: challenge includes nonce UTXO metadata only
+    # - Profile B: nonce_provider returns a pre-signed partial_tx template
     class ProofGateway < Gateway
-      NONCE_SIGHASH = ::BSV::Transaction::Sighash::SINGLE_FORK_ID_ANYONE_CAN_PAY
       ACCEPTABLE_MEMPOOL_STATUSES = %w[SEEN_ON_NETWORK ANNOUNCED_TO_NETWORK MINED].freeze
 
-      # @param nonce_provider [#call] callable returning nonce UTXO hash
+      # @param nonce_provider [#call] callable returning nonce UTXO hash;
+      #   receives (rack_request, payee:, amount:) kwargs.
+      #   Profile B providers include :partial_tx (binary) in the response.
       # @param arc_client [#status] ARC client for mempool queries
-      # @param nonce_key [BSV::Primitives::PrivateKey, nil] key for signing nonce input (Profile B)
       # @param payee_locking_script_hex [String, nil] payee script (falls back to config)
-      def initialize(nonce_provider:, arc_client:, nonce_key: nil,
+      def initialize(nonce_provider:, arc_client:,
                      payee_locking_script_hex: nil, wallet: nil, challenge_secret: nil)
         super(payee_locking_script_hex: payee_locking_script_hex, wallet: wallet,
               challenge_secret: challenge_secret)
         @nonce_provider = nonce_provider
         @arc_client = arc_client
-        @nonce_key = nonce_key
       end
 
       def challenge_headers(rack_request, route)
@@ -58,57 +56,14 @@ module X402
 
       private
 
-      # Build a Profile B template: nonce input (signed 0xC3) + payment + OP_RETURN.
-      # The 0xC3 signature commits to output 0 (payment) only.
-      # The OP_RETURN is added AFTER signing — it's unsigned data.
-      # Delegated clients should pop the OP_RETURN before adding their change
-      # (to preserve SIGHASH_SINGLE index alignment) and re-append it last.
-      # Falls back to base class (Profile A) when nonce_key is nil.
-      def build_proof_template(rack_request, route, nonce)
-        return super(rack_request, route) unless @nonce_key
-
-        validate_nonce_key!(nonce)
-
-        tx = ::BSV::Transaction::Transaction.new
-
-        # Input 0: nonce UTXO (will be signed with 0xC3)
-        nonce_script = ::BSV::Script::Script.from_hex(nonce[:locking_script_hex])
-        nonce_input = ::BSV::Transaction::TransactionInput.new(
-          prev_tx_id: [nonce[:txid]].pack("H*").reverse,
-          prev_tx_out_index: nonce[:vout]
-        )
-        nonce_input.source_satoshis = nonce[:satoshis]
-        nonce_input.source_locking_script = nonce_script
-        tx.add_input(nonce_input)
-
-        # Output 0: payment (committed by 0xC3 signature on input 0)
-        payee_hex = derive_payee_hex
-        payee_script = ::BSV::Script::Script.from_hex(payee_hex)
-        tx.add_output(::BSV::Transaction::TransactionOutput.new(
-                        satoshis: route.amount_sats,
-                        locking_script: payee_script
-                      ))
-
-        # Sign input 0 with 0xC3 (commits to output 0 only)
-        tx.sign(0, @nonce_key, NONCE_SIGHASH)
-
-        # Output 1: OP_RETURN binding (added AFTER signing — unsigned)
-        binding_hash = request_binding_hash(rack_request)
-        tx.add_output(::BSV::Transaction::TransactionOutput.new(
-                        satoshis: 0,
-                        locking_script: build_op_return_script(binding_hash)
-                      ))
-
-        [tx, payee_hex]
-      end
-
       def build_merkleworks_challenge(rack_request, route)
-        nonce = @nonce_provider.call(rack_request)
         config = X402.configuration
         payee_hex = derive_payee_hex
 
-        # Build template if Profile B
-        template, = build_proof_template(rack_request, route, nonce) if @nonce_key
+        nonce = @nonce_provider.call(rack_request, payee: payee_hex, amount: route.amount_sats)
+
+        # Profile B: provider returns a pre-signed partial_tx (binary)
+        template_binary = nonce[:partial_tx]
 
         attrs = {
           version: Challenge::CURRENT_VERSION,
@@ -128,8 +83,16 @@ module X402
           expires_at: Time.now.to_i + Challenge::DEFAULT_TTL
         }
 
-        # Profile B: include pre-signed template (not part of canonical hash)
-        attrs[:partial_tx_b64] = Base64.strict_encode64(template.to_binary) if template
+        if template_binary
+          # Deserialise the treasury's template and append OP_RETURN
+          tx = ::BSV::Transaction::Transaction.from_binary(template_binary)
+          binding_hash = request_binding_hash(rack_request)
+          tx.add_output(::BSV::Transaction::TransactionOutput.new(
+                          satoshis: 0,
+                          locking_script: build_op_return_script(binding_hash)
+                        ))
+          attrs[:partial_tx_b64] = Base64.strict_encode64(tx.to_binary)
+        end
 
         Challenge.new(attrs)
       end
@@ -155,7 +118,7 @@ module X402
         transaction = decode_transaction(proof)
         check_txid!(transaction, proof)
         check_nonce_input!(transaction, challenge)
-        verify_nonce_provenance!(transaction, challenge) if @nonce_key
+        verify_nonce_provenance!(transaction, challenge) if challenge.partial_tx_b64
         server_payee_hex = resolve_static_payee_hex
         verify_payment_output!(transaction, route, server_payee_hex)
         transaction
@@ -225,16 +188,6 @@ module X402
         raise
       rescue StandardError
         raise VerificationError.new("mempool check failed", status: 502)
-      end
-
-      # Validate that the nonce key matches the nonce UTXO's P2PKH locking script
-      def validate_nonce_key!(nonce)
-        expected_h160 = @nonce_key.public_key.hash160.unpack1("H*")
-        expected_script = "76a914#{expected_h160}88ac"
-        return if nonce[:locking_script_hex] == expected_script
-
-        raise X402::ConfigurationError,
-              "nonce_key does not match nonce UTXO locking script"
       end
     end
   end

--- a/lib/x402/configuration.rb
+++ b/lib/x402/configuration.rb
@@ -12,8 +12,8 @@ module X402
     ].freeze
 
     PROOF_GATEWAY_KNOWN_OPTS = %i[
-      arc_client payee_locking_script_hex nonce_provider nonce_key
-      nonce_wif wallet challenge_secret
+      arc_client payee_locking_script_hex nonce_provider
+      wallet challenge_secret
     ].freeze
 
     BRC105_GATEWAY_KNOWN_OPTS = %i[
@@ -151,24 +151,14 @@ module X402
       klass.new(**opts)
     end
 
-    def build_proof_gateway(klass, options) # rubocop:disable Metrics/PerceivedComplexity
+    def build_proof_gateway(klass, options)
       reject_unknown_options!(:proof_gateway, options, PROOF_GATEWAY_KNOWN_OPTS)
 
       raise ConfigurationError, "proof_gateway requires nonce_provider:" unless options.key?(:nonce_provider)
 
-      if options.key?(:nonce_wif) && options.key?(:nonce_key)
-        raise ConfigurationError, "proof_gateway: nonce_wif: and nonce_key: are mutually exclusive"
-      end
-
       opts = { arc_client: options[:arc_client] || shared_arc_client,
                payee_locking_script_hex: options[:payee_locking_script_hex] || payee_locking_script_hex,
                nonce_provider: options[:nonce_provider] }
-
-      if options.key?(:nonce_wif)
-        opts[:nonce_key] = ::BSV::Primitives::PrivateKey.from_wif(options[:nonce_wif])
-      elsif options.key?(:nonce_key)
-        opts[:nonce_key] = options[:nonce_key]
-      end
 
       %i[wallet challenge_secret].each do |key|
         opts[key] = options[key] if options.key?(key)

--- a/spec/e2e/proof_gateway_delegated_e2e_spec.rb
+++ b/spec/e2e/proof_gateway_delegated_e2e_spec.rb
@@ -73,7 +73,32 @@ RSpec.describe "ProofGateway e2e with fee delegation", :e2e do
       nonce = mint_nonce!
       E2ELogger.tx("Nonce UTXO", nonce[:txid])
       E2ELogger.result("ARC status", nonce[:arc_status])
-      nonce_provider = ->(_req) { nonce }
+
+      # Provider builds and signs the template (treasury responsibility)
+      t_key = treasury_key
+      nonce_provider = lambda { |_req, payee:, amount:|
+        tx = BSV::Transaction::Transaction.new
+
+        nonce_script = BSV::Script::Script.from_hex(nonce[:locking_script_hex])
+        nonce_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: [nonce[:txid]].pack("H*").reverse,
+          prev_tx_out_index: nonce[:vout]
+        )
+        nonce_input.source_satoshis = nonce[:satoshis]
+        nonce_input.source_locking_script = nonce_script
+        tx.add_input(nonce_input)
+
+        payee_script = BSV::Script::Script.from_hex(payee)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(
+                        satoshis: amount,
+                        locking_script: payee_script
+                      ))
+
+        sighash = BSV::Transaction::Sighash::SINGLE_FORK_ID_ANYONE_CAN_PAY
+        tx.sign(0, t_key, sighash)
+
+        nonce.merge(partial_tx: tx.to_binary)
+      }
 
       E2ELogger.separator
 
@@ -83,7 +108,6 @@ RSpec.describe "ProofGateway e2e with fee delegation", :e2e do
       gateway = X402::BSV::ProofGateway.new(
         nonce_provider: nonce_provider,
         arc_client: proof_arc,
-        nonce_key: treasury_key,
         payee_locking_script_hex: payee_script_hex
       )
 

--- a/spec/e2e/proof_gateway_e2e_spec.rb
+++ b/spec/e2e/proof_gateway_e2e_spec.rb
@@ -54,7 +54,32 @@ RSpec.describe "ProofGateway e2e (Profile B)", :e2e do
       nonce = mint_nonce!
       E2ELogger.tx("Nonce UTXO", nonce[:txid])
       E2ELogger.result("ARC status", nonce[:arc_status])
-      nonce_provider = ->(_req) { nonce }
+
+      # Provider builds and signs the template (treasury responsibility)
+      t_key = treasury_key
+      nonce_provider = lambda { |_req, payee:, amount:|
+        tx = BSV::Transaction::Transaction.new
+
+        nonce_script = BSV::Script::Script.from_hex(nonce[:locking_script_hex])
+        nonce_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: [nonce[:txid]].pack("H*").reverse,
+          prev_tx_out_index: nonce[:vout]
+        )
+        nonce_input.source_satoshis = nonce[:satoshis]
+        nonce_input.source_locking_script = nonce_script
+        tx.add_input(nonce_input)
+
+        payee_script = BSV::Script::Script.from_hex(payee)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(
+                        satoshis: amount,
+                        locking_script: payee_script
+                      ))
+
+        sighash = BSV::Transaction::Sighash::SINGLE_FORK_ID_ANYONE_CAN_PAY
+        tx.sign(0, t_key, sighash)
+
+        nonce.merge(partial_tx: tx.to_binary)
+      }
 
       E2ELogger.separator
 
@@ -64,7 +89,6 @@ RSpec.describe "ProofGateway e2e (Profile B)", :e2e do
       gateway = X402::BSV::ProofGateway.new(
         nonce_provider: nonce_provider,
         arc_client: proof_arc,
-        nonce_key: treasury_key,
         payee_locking_script_hex: payee_script_hex
       )
 

--- a/spec/x402/bsv/proof_gateway_spec.rb
+++ b/spec/x402/bsv/proof_gateway_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe X402::BSV::ProofGateway do
   let(:nonce) do
     { txid: nonce_txid, vout: 0, satoshis: 1, locking_script_hex: "76a914#{"cc" * 20}88ac" }
   end
-  let(:nonce_provider) { ->(_req) { nonce } }
+  let(:nonce_provider) { ->(_req, **) { nonce } }
   let(:route) { X402::Configuration::Route.new(http_method: "GET", path: "/premium", amount_sats: 50) }
 
   let(:mock_arc) do
@@ -266,20 +266,49 @@ RSpec.describe X402::BSV::ProofGateway do
     end
   end
 
-  context "Profile B (with nonce_key)" do
+  context "Profile B (provider builds template)" do
     let(:nonce_key) { BSV::Primitives::PrivateKey.generate }
     let(:nonce_h160) { nonce_key.public_key.hash160.unpack1("H*") }
     let(:nonce_locking_script) { "76a914#{nonce_h160}88ac" }
-    let(:profile_b_nonce) do
-      { txid: nonce_txid, vout: 0, satoshis: 1, locking_script_hex: nonce_locking_script }
+    let(:nonce_sighash) { BSV::Transaction::Sighash::SINGLE_FORK_ID_ANYONE_CAN_PAY }
+
+    # Provider builds and signs the template itself (treasury responsibility)
+    let(:profile_b_provider) do
+      key = nonce_key
+      sighash = nonce_sighash
+      lambda do |_req, payee:, amount:|
+        tx = BSV::Transaction::Transaction.new
+
+        # Input 0: nonce UTXO
+        nonce_script = BSV::Script::Script.from_hex("76a914#{key.public_key.hash160.unpack1("H*")}88ac")
+        nonce_input = BSV::Transaction::TransactionInput.new(
+          prev_tx_id: [nonce_txid].pack("H*").reverse,
+          prev_tx_out_index: 0
+        )
+        nonce_input.source_satoshis = 1
+        nonce_input.source_locking_script = nonce_script
+        tx.add_input(nonce_input)
+
+        # Output 0: payment
+        payee_script = BSV::Script::Script.from_hex(payee)
+        tx.add_output(BSV::Transaction::TransactionOutput.new(
+                        satoshis: amount,
+                        locking_script: payee_script
+                      ))
+
+        # Sign input 0 with 0xC3
+        tx.sign(0, key, sighash)
+
+        { txid: nonce_txid, vout: 0, satoshis: 1,
+          locking_script_hex: nonce_script.to_hex,
+          partial_tx: tx.to_binary }
+      end
     end
-    let(:profile_b_provider) { ->(_req) { profile_b_nonce } }
 
     let(:profile_b_gateway) do
       described_class.new(
         nonce_provider: profile_b_provider,
         arc_client: mock_arc,
-        nonce_key: nonce_key,
         payee_locking_script_hex: payee_hex
       )
     end
@@ -312,13 +341,17 @@ RSpec.describe X402::BSV::ProofGateway do
       it "sha256_hex is the same with and without partial_tx_b64" do
         request = mock_request
 
-        # Profile B challenge
+        # Profile B challenge (provider returns partial_tx)
         b_headers = profile_b_gateway.challenge_headers(request, route)
         b_challenge = X402::Challenge.from_header(b_headers["X402-Challenge"])
 
-        # Profile A challenge (same params, no nonce_key)
+        # Profile A challenge (provider returns bare UTXO metadata, no partial_tx)
+        profile_a_provider = lambda { |_req, **|
+          { txid: nonce_txid, vout: 0, satoshis: 1,
+            locking_script_hex: nonce_locking_script }
+        }
         a_gw = described_class.new(
-          nonce_provider: profile_b_provider,
+          nonce_provider: profile_a_provider,
           arc_client: mock_arc,
           payee_locking_script_hex: payee_hex
         )
@@ -372,22 +405,27 @@ RSpec.describe X402::BSV::ProofGateway do
         expect(result.txid).to eq(template.txid_hex)
       end
 
-      it "rejects proof when nonce signed by wrong key" do
-        wrong_key = BSV::Primitives::PrivateKey.generate
-        wrong_h160 = wrong_key.public_key.hash160.unpack1("H*")
-        wrong_nonce = { txid: nonce_txid, vout: 0, satoshis: 1,
-                        locking_script_hex: "76a914#{wrong_h160}88ac" }
+      it "verifies nonce provenance based on challenge partial_tx_b64 presence" do
+        request = mock_request
 
-        # Gateway with wrong nonce key — nonce UTXO doesn't match
-        expect do
-          wrong_gw = described_class.new(
-            nonce_provider: ->(_req) { wrong_nonce },
-            arc_client: mock_arc,
-            nonce_key: nonce_key, # key doesn't match wrong_nonce
-            payee_locking_script_hex: payee_hex
-          )
-          wrong_gw.challenge_headers(mock_request, route)
-        end.to raise_error(X402::ConfigurationError, /nonce_key/)
+        # Profile B challenge includes partial_tx_b64 — settlement will verify provenance
+        headers = profile_b_gateway.challenge_headers(request, route)
+        challenge_header = headers["X402-Challenge"]
+        challenge = X402::Challenge.from_header(challenge_header)
+        expect(challenge.partial_tx_b64).not_to be_nil
+
+        # Profile A provider (no partial_tx) — settlement skips provenance check
+        profile_a_provider = lambda { |_req, **|
+          { txid: nonce_txid, vout: 0, satoshis: 1, locking_script_hex: nonce_locking_script }
+        }
+        a_gw = described_class.new(
+          nonce_provider: profile_a_provider,
+          arc_client: mock_arc,
+          payee_locking_script_hex: payee_hex
+        )
+        a_headers = a_gw.challenge_headers(request, route)
+        a_challenge = X402::Challenge.from_header(a_headers["X402-Challenge"])
+        expect(a_challenge.partial_tx_b64).to be_nil
       end
 
       it "rejects proof with nonce at index 1 instead of index 0" do

--- a/spec/x402/configuration_spec.rb
+++ b/spec/x402/configuration_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe X402::Configuration do
 
   describe "gateway construction (build phase)" do
     let(:arc_double) { instance_double("BSV::Network::ARC") }
-    let(:nonce_provider) { ->(_req, _route) { { txid: "abc", vout: 0, satoshis: 100 } } }
+    let(:nonce_provider) { ->(_req, **) { { txid: "abc", vout: 0, satoshis: 100 } } }
 
     before do
       config.domain = "example.com"
@@ -336,25 +336,6 @@ RSpec.describe X402::Configuration do
         config.enable :proof_gateway
         expect { config.validate! }.to raise_error(
           X402::ConfigurationError, /nonce_provider/
-        )
-      end
-
-      it "expands nonce_wif to nonce_key" do
-        private_key = instance_double("BSV::Primitives::PrivateKey")
-        allow(BSV::Primitives::PrivateKey).to receive(:from_wif)
-          .with("L3nonce")
-          .and_return(private_key)
-
-        config.enable :proof_gateway, nonce_provider: nonce_provider, nonce_wif: "L3nonce"
-        config.validate!
-
-        expect(config.gateways.first).to be_a(X402::BSV::ProofGateway)
-      end
-
-      it "raises when both nonce_wif and nonce_key are provided" do
-        config.enable :proof_gateway, nonce_provider: nonce_provider, nonce_wif: "L3x", nonce_key: :key
-        expect { config.validate! }.to raise_error(
-          X402::ConfigurationError, /nonce_wif.*nonce_key.*mutually exclusive/
         )
       end
 


### PR DESCRIPTION
## Summary

- Remove `nonce_key:` from ProofGateway constructor and configuration DSL — the gateway never holds a private key
- Extend `nonce_provider` interface with `payee:` and `amount:` kwargs; providers returning `partial_tx:` trigger Profile B
- Gateway detects profile from provider response, appends OP_RETURN after deserialising the treasury's template
- Settlement verifies nonce provenance via `challenge.partial_tx_b64` presence instead of `@nonce_key`
- Update all unit specs, e2e specs, and documentation to reflect the new trust boundary: `[(X)+(B)] <-> [(T)]`

Closes #30

## Sub-issues

- #47 Core refactor — extend nonce_provider, remove nonce_key
- #48 Config DSL — remove nonce_key/nonce_wif
- #49 Unit specs — updated provider lambdas, Profile B detection tests
- #50 E2e specs — signing moved into provider callable
- #51 Documentation — updated Profile B description and trust boundary

## Test plan

- [x] `bundle exec rake` passes (180 examples, 0 failures, 0 RuboCop offences)
- [ ] E2e tests on testnet (requires TREASURY_WIF, CLIENT_WIF, ARC_API_KEY)
- [ ] Review trust boundary change: gateway no longer holds keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)