### PR TITLE
feat: PaymentObserver — voluntary ungated payment relay

### DIFF
--- a/lib/x402.rb
+++ b/lib/x402.rb
@@ -5,6 +5,8 @@ require_relative "x402/errors"
 require_relative "x402/settlement_result"
 require_relative "x402/configuration"
 require_relative "x402/middleware"
+require_relative "x402/payment_observer"
+require_relative "x402/settlement_worker"
 
 module X402
   class << self

--- a/lib/x402/payment_observer.rb
+++ b/lib/x402/payment_observer.rb
@@ -57,10 +57,16 @@ module X402
         tx_binary = extract_and_validate(value)
         next unless tx_binary
 
-        @worker.enqueue(tx_binary)
-        @on_payment&.call(tx_binary)
+        enqueue_payment(tx_binary)
         break
       end
+    end
+
+    def enqueue_payment(tx_binary)
+      @worker.enqueue(tx_binary)
+      @on_payment&.call(tx_binary)
+    rescue StandardError
+      # Never let enqueue/callback failures break the request pass-through
     end
 
     def extract_and_validate(proof_payload)

--- a/spec/x402/payment_observer_spec.rb
+++ b/spec/x402/payment_observer_spec.rb
@@ -154,12 +154,12 @@ RSpec.describe X402::PaymentObserver do
     let(:app) do
       described_class.new(inner_app, worker: mock_worker,
                                      payee_locking_script_hex: payee_hex,
-                                     proof_headers: %w[X-BSV-Payment])
+                                     proof_headers: %w[X-Custom-Payment])
     end
 
     it "detects payment on custom header" do
       env = Rack::MockRequest.env_for("/anything", method: "POST")
-      env["HTTP_X_BSV_PAYMENT"] = build_proof
+      env["HTTP_X_CUSTOM_PAYMENT"] = build_proof
 
       app.call(env)
 
@@ -218,13 +218,13 @@ RSpec.describe X402::PaymentObserver do
     let(:app) do
       described_class.new(inner_app, worker: mock_worker,
                                      payee_locking_script_hex: payee_hex,
-                                     proof_headers: %w[Payment-Signature X-BSV-Payment])
+                                     proof_headers: %w[Payment-Signature X-Custom-Payment])
     end
 
     it "uses the first matching header" do
       env = Rack::MockRequest.env_for("/anything", method: "POST")
       env["HTTP_PAYMENT_SIGNATURE"] = build_proof
-      env["HTTP_X_BSV_PAYMENT"] = build_proof
+      env["HTTP_X_CUSTOM_PAYMENT"] = build_proof
 
       app.call(env)
 


### PR DESCRIPTION
## Summary
- New `X402::PaymentObserver` Rack middleware — watches for payment headers, enqueues to settlement worker, passes through unconditionally
- ~60 lines of code, zero dependencies beyond Rack
- Configurable proof headers (default: `Payment-Signature`)
- Optional `on_payment` callback for application-level tracking (e.g. session UTXO tracking)
- Invalid/malformed payments silently ignored — the observer never blocks requests
- Shares the `SettlementWorker` interface with PayGateway's async path

## Usage
```ruby
use X402::PaymentObserver,
  worker: settlement_worker,
  on_payment: ->(tx_binary) { track_session_payment(tx_binary) }
use X402::Middleware
run MyApp
```

## Test plan
- [x] 224 examples pass (12 new)
- [x] RuboCop clean
- [x] Payment detection, pass-through, invalid handling, custom headers, callback, multiple headers

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)