### PR TITLE
fix: accept base64 derivationSuffix in BRC-105 gateway

### DIFF
--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -24,6 +24,7 @@ module X402
       NETWORK = "bsv:mainnet"
       COMPRESSED_PUBKEY_HEX = /\A0[23][0-9a-fA-F]{64}\z/
       MAX_DERIVATION_BYTES = 64
+      PRINTABLE_ASCII = /\A[\x20-\x7E]+\z/
 
       # @param key_deriver [BSV::Wallet::KeyDeriver] provides identity key + BRC-42 derivation
       # @param prefix_store [#store!, #valid?, #consume!] replay protection for derivation prefixes
@@ -96,14 +97,26 @@ module X402
       end
 
       def validate_prefix_and_suffix!(prefix, suffix)
-        validate_derivation_component!("derivationPrefix", prefix)
-        validate_derivation_component!("derivationSuffix", suffix)
+        validate_hex!("derivationPrefix", prefix)
+        validate_suffix!("derivationSuffix", suffix)
       end
 
-      def validate_derivation_component!(name, value)
+      # Prefix is server-generated hex (SecureRandom.hex).
+      def validate_hex!(name, value)
         raise VerificationError.new("missing #{name}", status: 400) if value.nil?
         unless value.is_a?(String) && !value.empty? &&
                value.bytesize <= MAX_DERIVATION_BYTES && value.match?(/\A[0-9a-f]+\z/)
+          raise VerificationError.new("invalid #{name} format", status: 400)
+        end
+      end
+
+      # Suffix is client-generated — the BRC-105 spec does not constrain the
+      # format. Reference implementations (BRC-121, bsv-x402) use base64.
+      # We accept any printable ASCII string within the size limit.
+      def validate_suffix!(name, value)
+        raise VerificationError.new("missing #{name}", status: 400) if value.nil?
+        unless value.is_a?(String) && !value.empty? &&
+               value.bytesize <= MAX_DERIVATION_BYTES && value.match?(PRINTABLE_ASCII)
           raise VerificationError.new("invalid #{name} format", status: 400)
         end
       end

--- a/spec/x402/bsv/brc105_gateway_spec.rb
+++ b/spec/x402/bsv/brc105_gateway_spec.rb
@@ -312,6 +312,31 @@ RSpec.describe X402::BSV::BRC105Gateway do
           .to raise_error(X402::VerificationError, /invalid derivationSuffix format/) { |e| expect(e.status).to eq(400) }
       end
 
+      it "rejects non-hex derivationPrefix" do
+        payload = JSON.generate(
+          "derivationPrefix" => "SGVsbG8=", "derivationSuffix" => suffix, "transaction" => "AA=="
+        )
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /invalid derivationPrefix format/) { |e| expect(e.status).to eq(400) }
+      end
+
+      # BRC-105/BRC-121: suffix is client-generated, reference impls use base64
+      it "accepts base64 derivationSuffix" do
+        b64_suffix = Base64.strict_encode64(SecureRandom.random_bytes(16))
+        b64_derived = real_key_deriver.derive_public_key(
+          [2, "3241645161d8"], "#{prefix} #{b64_suffix}", "anyone", for_self: true
+        )
+        h160 = b64_derived.hash160.unpack1("H*")
+        b64_script = "76a914#{h160}88ac"
+
+        transaction = build_payment_tx(amount: 1000, script_hex: b64_script)
+        payload = build_proof_payload(prefix: prefix, suffix: b64_suffix, transaction: transaction)
+
+        result = real_gateway.settle!("x-bsv-payment", payload, request, route)
+        expect(result).to be_a(X402::SettlementResult)
+      end
+
       it "rejects missing transaction" do
         payload = JSON.generate({ "derivationPrefix" => prefix, "derivationSuffix" => suffix })
 


### PR DESCRIPTION
## Summary

- Split `validate_derivation_component!` into `validate_hex!` (prefix) and `validate_suffix!` (suffix)
- Prefix remains hex-only (server-generated via `SecureRandom.hex`)
- Suffix now accepts any printable ASCII within the 64-byte limit — accommodates base64 values from reference SDK implementations (BRC-121, bsv-x402)

## Test plan

- [x] 254 examples, 0 failures
- [x] RuboCop clean
- [x] New test: base64 suffix accepted through full settlement path
- [x] New test: non-hex prefix still rejected

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)