### PR TITLE
fix(proof-gateway): tolerate ARC propagation lag in check_mempool!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **ProofGateway mempool check is now propagation-tolerant.**
+  `check_mempool!` retries ARC status (4 attempts, ~1.75s total
+  worst case) to absorb the window between broadcast and
+  `SEEN_ON_NETWORK`. The acceptable-status whitelist has been
+  broadened to include every non-error ARC state (`RECEIVED`,
+  `STORED`, `ANNOUNCED_TO_NETWORK`, `REQUESTED_BY_NETWORK`,
+  `SENT_TO_NETWORK`, `ACCEPTED_BY_NETWORK`, `SEEN_ON_NETWORK`,
+  `MINED`). Matches the merkleworks reference implementation's
+  `visible` check — Bitcoin's single-spend at the network layer
+  remains the actual replay gate. Error message now surfaces the
+  last observed status to aid ops debugging.
+
 ## [0.6.0] - 2026-04-05
 
 ### Added

--- a/lib/x402/bsv/proof_gateway.rb
+++ b/lib/x402/bsv/proof_gateway.rb
@@ -20,7 +20,39 @@ module X402
     # - Profile A: challenge includes nonce UTXO metadata only
     # - Profile B: nonce_provider returns a pre-signed partial_tx template
     class ProofGateway < Gateway
-      ACCEPTABLE_MEMPOOL_STATUSES = %w[SEEN_ON_NETWORK ANNOUNCED_TO_NETWORK MINED].freeze
+      # ARC status values that confirm ARC knows about the tx and hasn't
+      # rejected it. ARC progresses a broadcast tx through roughly:
+      #
+      #   RECEIVED → STORED → ANNOUNCED_TO_NETWORK →
+      #   REQUESTED_BY_NETWORK → SENT_TO_NETWORK →
+      #   ACCEPTED_BY_NETWORK → SEEN_ON_NETWORK → MINED
+      #
+      # Any of these mean "ARC has the tx and is processing it"; the
+      # client has demonstrably broadcast. The bad states we must reject
+      # are UNKNOWN (never seen), REJECTED, DOUBLE_SPEND_ATTEMPTED —
+      # anything in this whitelist is acceptable.
+      #
+      # Bitcoin's single-spend guarantee at the network layer is the
+      # actual replay gate; this check just confirms the client fulfilled
+      # their broadcast obligation. Matches the merkleworks reference
+      # implementation's `visible` check.
+      ACCEPTABLE_MEMPOOL_STATUSES = %w[
+        RECEIVED
+        STORED
+        ANNOUNCED_TO_NETWORK
+        REQUESTED_BY_NETWORK
+        SENT_TO_NETWORK
+        ACCEPTED_BY_NETWORK
+        SEEN_ON_NETWORK
+        MINED
+      ].freeze
+
+      # Mempool polling retry schedule. ARC typically returns an
+      # intermediate status (RECEIVED, STORED, SENT_TO_NETWORK) for a
+      # brief window after broadcast before progressing to
+      # SEEN_ON_NETWORK. A short retry loop absorbs that race without
+      # adding stateful polling infrastructure.
+      MEMPOOL_RETRY_DELAYS_SECONDS = [0.25, 0.5, 1.0].freeze
 
       # @param nonce_provider [#call] callable returning nonce UTXO hash;
       #   receives (rack_request, payee:, amount:) kwargs.
@@ -200,11 +232,26 @@ module X402
         raise VerificationError.new("no output pays >= #{required_sats} sats to payee", status: 402)
       end
 
+      # Poll ARC for the tx status, retrying briefly to absorb the
+      # propagation lag between broadcast and SEEN_ON_NETWORK. Returns
+      # on the first acceptable status; raises if no attempt succeeds.
       def check_mempool!(txid)
-        response = @arc_client.status(txid)
-        return if ACCEPTABLE_MEMPOOL_STATUSES.include?(response.tx_status)
+        attempts = MEMPOOL_RETRY_DELAYS_SECONDS.length + 1
+        last_status = nil
 
-        raise VerificationError.new("transaction not yet visible in mempool", status: 402)
+        attempts.times do |i|
+          last_status = @arc_client.status(txid).tx_status
+          break if ACCEPTABLE_MEMPOOL_STATUSES.include?(last_status)
+
+          sleep(MEMPOOL_RETRY_DELAYS_SECONDS[i]) if i < MEMPOOL_RETRY_DELAYS_SECONDS.length
+        end
+
+        return if ACCEPTABLE_MEMPOOL_STATUSES.include?(last_status)
+
+        raise VerificationError.new(
+          "transaction not yet visible in mempool (last status: #{last_status || "unknown"})",
+          status: 402
+        )
       rescue VerificationError
         raise
       rescue StandardError

--- a/spec/x402/bsv/proof_gateway_spec.rb
+++ b/spec/x402/bsv/proof_gateway_spec.rb
@@ -218,6 +218,9 @@ RSpec.describe X402::BSV::ProofGateway do
     end
 
     it "raises when mempool check fails" do
+      # Zero out retry delays so the spec doesn't wait in real time.
+      stub_const("#{described_class}::MEMPOOL_RETRY_DELAYS_SECONDS", [].freeze)
+
       failing_arc = Object.new
       def failing_arc.status(_txid)
         raise "connection refused"
@@ -254,6 +257,85 @@ RSpec.describe X402::BSV::ProofGateway do
 
       expect { failing_gw.settle!("X402-Proof", proof_header2, request, route) }
         .to raise_error(X402::VerificationError, /mempool/)
+    end
+
+    it "retries the mempool check until ARC reports an acceptable status" do
+      stub_const("#{described_class}::MEMPOOL_RETRY_DELAYS_SECONDS", [0.0, 0.0, 0.0].freeze)
+
+      # ARC first reports UNKNOWN (the tx hasn't been observed yet),
+      # then SEEN_ON_NETWORK on the next poll. The gateway should
+      # accept the retry and return a SettlementResult.
+      status_sequence = %w[UNKNOWN SEEN_ON_NETWORK]
+      arc_stub = Object.new
+      arc_stub.define_singleton_method(:status) do |_txid|
+        Struct.new(:txid, :tx_status).new(nil, status_sequence.shift || "SEEN_ON_NETWORK")
+      end
+
+      retrying_gw = described_class.new(
+        nonce_provider: nonce_provider,
+        arc_client: arc_stub,
+        payee_locking_script_hex: payee_hex
+      )
+
+      request = mock_request
+      headers = retrying_gw.challenge_headers(request, route)
+      challenge = X402::Challenge.from_header(headers["X402-Challenge"])
+
+      transaction = BSV::Transaction::Transaction.new
+      transaction.add_input(BSV::Transaction::TransactionInput.new(
+                              prev_tx_id: [nonce_txid].pack("H*").reverse,
+                              prev_tx_out_index: 0,
+                              unlocking_script: BSV::Script::Script.new("\x00".b)
+                            ))
+      transaction.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 50, locking_script: payee_script))
+
+      proof_data = {
+        challenge_sha256: challenge.sha256_hex,
+        payment: { rawtx_b64: Base64.strict_encode64(transaction.to_binary), txid: transaction.txid_hex }
+      }
+      proof_header = X402::Base64Url.encode(JSON.generate(proof_data))
+      request.env["HTTP_X402_CHALLENGE"] = headers["X402-Challenge"]
+
+      result = retrying_gw.settle!("X402-Proof", proof_header, request, route)
+      expect(result).to be_a(X402::SettlementResult)
+      expect(status_sequence).to be_empty # both calls consumed
+    end
+
+    it "surfaces the last observed tx_status when all retries fail" do
+      stub_const("#{described_class}::MEMPOOL_RETRY_DELAYS_SECONDS", [0.0].freeze)
+
+      arc_stub = Object.new
+      def arc_stub.status(_txid)
+        Struct.new(:txid, :tx_status).new(nil, "UNKNOWN")
+      end
+
+      stuck_gw = described_class.new(
+        nonce_provider: nonce_provider,
+        arc_client: arc_stub,
+        payee_locking_script_hex: payee_hex
+      )
+
+      request = mock_request
+      headers = stuck_gw.challenge_headers(request, route)
+      challenge = X402::Challenge.from_header(headers["X402-Challenge"])
+
+      transaction = BSV::Transaction::Transaction.new
+      transaction.add_input(BSV::Transaction::TransactionInput.new(
+                              prev_tx_id: [nonce_txid].pack("H*").reverse,
+                              prev_tx_out_index: 0,
+                              unlocking_script: BSV::Script::Script.new("\x00".b)
+                            ))
+      transaction.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 50, locking_script: payee_script))
+
+      proof_data = {
+        challenge_sha256: challenge.sha256_hex,
+        payment: { rawtx_b64: Base64.strict_encode64(transaction.to_binary), txid: transaction.txid_hex }
+      }
+      proof_header = X402::Base64Url.encode(JSON.generate(proof_data))
+      request.env["HTTP_X402_CHALLENGE"] = headers["X402-Challenge"]
+
+      expect { stuck_gw.settle!("X402-Proof", proof_header, request, route) }
+        .to raise_error(X402::VerificationError, /UNKNOWN/)
     end
 
     it "raises when X402-Challenge header is missing" do


### PR DESCRIPTION
## Summary

- `check_mempool!` now retries ARC status up to 4 times (0.25s / 0.5s / 1s backoff, ~1.75s worst case) before giving up
- Acceptable-status whitelist broadened from 3 → 8 statuses: `RECEIVED`, `STORED`, `ANNOUNCED_TO_NETWORK`, `REQUESTED_BY_NETWORK`, `SENT_TO_NETWORK`, `ACCEPTED_BY_NETWORK`, `SEEN_ON_NETWORK`, `MINED` — every non-error ARC state
- Error message surfaces the last observed status to aid ops debugging (e.g. `"transaction not yet visible in mempool (last status: UNKNOWN)"`)

## Why

Discovered running the ProofGateway e2e specs against BSV testnet — both were failing at `check_mempool!`. Reproduced against master (pre-ChallengeStore PR) confirming it's pre-existing: ARC was returning `STORED` / `SENT_TO_NETWORK` when the server polled immediately after the client's broadcast, and neither was in the whitelist.

Two orthogonal problems:

1. **Propagation lag**: there's a real window between broadcast and `SEEN_ON_NETWORK` while ARC announces the tx to peers and waits for relay back. A single poll races that window. The retry loop absorbs it.
2. **Over-strict whitelist**: the old list (`SEEN_ON_NETWORK`, `ANNOUNCED_TO_NETWORK`, `MINED`) rejected legitimate intermediate states where the tx is known to ARC and being processed. Matches what the merkleworks reference implementation does — their `visible` check is true from `STORED` onwards. Bitcoin's single-spend at the network layer is the actual replay gate; the mempool check just confirms the client fulfilled their broadcast obligation.

## Test plan

- [x] `bundle exec rake` — 283 examples, 0 failures; rubocop clean (pre-existing `.ruby-lsp/Gemfile` noise unrelated)
- [x] New unit specs in `proof_gateway_spec.rb`:
  - `retries the mempool check until ARC reports an acceptable status` — sequence `UNKNOWN → SEEN_ON_NETWORK`
  - `surfaces the last observed tx_status when all retries fail` — stuck on `UNKNOWN`, error message includes the status
- [x] Existing `raises when mempool check fails` spec uses `stub_const` to zero out retry delays so it doesn't slow the suite
- [x] **E2e against BSV testnet** — both `proof_gateway_e2e_spec.rb` and `proof_gateway_delegated_e2e_spec.rb` now pass (full flow: treasury mint → challenge → client payment → delegator co-sign → ARC broadcast → server verification → 200 OK)

## Notes

- `MEMPOOL_RETRY_DELAYS_SECONDS` is a class constant (`[0.25, 0.5, 1.0]`) rather than a constructor kwarg — minimal surface, tests override with `stub_const`
- Worst-case added latency on the success path is ~0 (ARC progresses to an acceptable state on the first poll in normal conditions); on the failure path it's ~1.75s before giving up
- Unrelated to #112 (ChallengeStore) but discovered during its e2e verification. Will unblock clean e2e CI for the ProofGateway once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)