### PR TITLE
feat(config): parameterise BSV network via configuration

### DIFF
--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -21,7 +21,6 @@ module X402
     class BRC105Gateway
       PROTOCOL_ID = [2, "3241645161d8"].freeze
       PROOF_HEADER = "x-bsv-payment"
-      NETWORK = "bsv:mainnet"
       COMPRESSED_PUBKEY_HEX = /\A0[23][0-9a-f]{64}\z/
       MAX_DERIVATION_BYTES = 64
       PRINTABLE_ASCII = /\A[\x20-\x7E]+\z/
@@ -243,7 +242,7 @@ module X402
         receipt = {
           "success" => true,
           "transaction" => transaction.txid_hex,
-          "network" => NETWORK
+          "network" => X402.configuration.network
         }
         SettlementResult.new(
           receipt_headers: {
@@ -251,7 +250,7 @@ module X402
             "x-bsv-payment-result" => Base64.strict_encode64(JSON.generate(receipt))
           },
           txid: transaction.txid_hex,
-          network: NETWORK
+          network: X402.configuration.network
         )
       end
     end

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -51,7 +51,6 @@ module X402
     #   settle!(header_name, proof_payload, rack_request, route) → SettlementResult
     class BRC121Gateway
       PROOF_HEADER = "x-bsv-beef"
-      NETWORK = "bsv:mainnet"
       FRESHNESS_WINDOW_MS = 30_000
       COMPRESSED_PUBKEY_HEX = /\A0[23][0-9a-f]{64}\z/
       # BRC-29 derivation prefix is base64. Cap length at 128 chars
@@ -273,7 +272,7 @@ module X402
         SettlementResult.new(
           receipt_headers: { "x-bsv-payment-satoshis-paid" => paid_sats.to_s },
           txid: transaction.txid_hex,
-          network: NETWORK
+          network: X402.configuration.network
         )
       end
 

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -13,7 +13,7 @@ module X402
     #
     # Server broadcasts via ARC. No nonces needed — ARC is the replay gate.
     class PayGateway < Gateway
-      DEFAULT_ARC_WAIT_FOR = "SEEN_ON_X402.configuration.network"
+      DEFAULT_ARC_WAIT_FOR = "SEEN_ON_NETWORK"
       DEFAULT_ARC_TIMEOUT = 5
       DEFAULT_MAX_TIMEOUT_SECONDS = 60
       ASSET = "BSV"

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -13,10 +13,9 @@ module X402
     #
     # Server broadcasts via ARC. No nonces needed — ARC is the replay gate.
     class PayGateway < Gateway
-      DEFAULT_ARC_WAIT_FOR = "SEEN_ON_NETWORK"
+      DEFAULT_ARC_WAIT_FOR = "SEEN_ON_X402.configuration.network"
       DEFAULT_ARC_TIMEOUT = 5
       DEFAULT_MAX_TIMEOUT_SECONDS = 60
-      NETWORK = "bsv:mainnet"
       ASSET = "BSV"
       SCHEME = "exact"
 
@@ -105,7 +104,7 @@ module X402
       def build_accept_entry(payee_hex, required_sats, template)
         {
           "scheme" => SCHEME,
-          "network" => NETWORK,
+          "network" => X402.configuration.network,
           "amount" => required_sats.to_s,
           "asset" => ASSET,
           "payTo" => payee_hex,
@@ -127,8 +126,8 @@ module X402
       def verify_accepted!(payload, required_sats)
         accepted = payload["accepted"]
         raise VerificationError.new("missing accepted field", status: 400) unless accepted
-        if accepted["network"] != NETWORK
-          raise VerificationError.new("network mismatch: expected #{NETWORK}", status: 400)
+        if accepted["network"] != X402.configuration.network
+          raise VerificationError.new("network mismatch: expected #{X402.configuration.network}", status: 400)
         end
 
         raw_amount = accepted["amount"]
@@ -206,11 +205,11 @@ module X402
       end
 
       def build_settlement_result(transaction)
-        receipt = { "success" => true, "transaction" => transaction.txid_hex, "network" => NETWORK }
+        receipt = { "success" => true, "transaction" => transaction.txid_hex, "network" => X402.configuration.network }
         SettlementResult.new(
           receipt_headers: { "Payment-Response" => Base64.strict_encode64(JSON.generate(receipt)) },
           txid: transaction.txid_hex,
-          network: NETWORK
+          network: X402.configuration.network
         )
       end
     end

--- a/lib/x402/bsv/proof_gateway.rb
+++ b/lib/x402/bsv/proof_gateway.rb
@@ -113,7 +113,7 @@ module X402
         check_mempool!(proof.txid)
         consume_challenge!(proof)
 
-        SettlementResult.new(txid: proof.txid, network: "bsv:mainnet")
+        SettlementResult.new(txid: proof.txid, network: X402.configuration.network)
       end
 
       private

--- a/lib/x402/configuration.rb
+++ b/lib/x402/configuration.rb
@@ -55,11 +55,14 @@ module X402
     # with a BRC-100 wallet and expose non-overlapping proof headers.
     DEFAULT_GATEWAYS = %i[pay_gateway brc121_gateway].freeze
 
+    VALID_NETWORKS = %w[bsv:mainnet bsv:testnet].freeze
+    DEFAULT_NETWORK = "bsv:mainnet"
+
     attr_accessor :domain, :payee_locking_script_hex, :gateways,
                   :arc_url, :arc_api_key, :arc_client, :server_wif, :wallet,
                   :exchange_rate_provider, :logger,
                   :status_endpoint_path, :status_endpoint_token
-    attr_reader :routes, :gateway_specs
+    attr_reader :routes, :gateway_specs, :network
 
     DEFAULT_STATUS_ENDPOINT_PATH = "/_x402/status"
 
@@ -67,6 +70,7 @@ module X402
       @routes = []
       @gateways = []
       @gateway_specs = []
+      @network = DEFAULT_NETWORK
       @logger = default_logger
       @status_endpoint_enabled = false
       @status_endpoint_path = DEFAULT_STATUS_ENDPOINT_PATH
@@ -91,6 +95,14 @@ module X402
     # @return [Boolean] whether the status endpoint should be served
     def status_endpoint_enabled?
       @status_endpoint_enabled
+    end
+
+    # Set the BSV network explicitly.
+    #
+    # @param value [String] e.g. "bsv:mainnet" or "bsv:testnet"
+    def network=(value)
+      @network = value
+      @network_explicit = true
     end
 
     private
@@ -189,6 +201,7 @@ module X402
     def validate!
       raise ConfigurationError, "domain is required" if domain.nil? || domain.empty?
 
+      resolve_network!
       validate_payee_source!
       auto_enable_default_gateways! if should_auto_enable_defaults?
       build_gateways_from_specs! if gateways.empty? && !gateway_specs.empty?
@@ -199,6 +212,32 @@ module X402
     end
 
     private
+
+    # Resolve the network identifier.
+    #
+    # Resolution order:
+    #   1. Explicit +config.network =+ (wins if set)
+    #   2. +BSV_NETWORK+ environment variable
+    #   3. +DEFAULT_NETWORK+ ("bsv:mainnet")
+    #
+    # Blank or empty values at any level are treated as unset and fall
+    # through to the next source.
+    def resolve_network!
+      @network = resolve_network_value
+      return if VALID_NETWORKS.include?(@network)
+
+      raise ConfigurationError,
+            "invalid network #{@network.inspect} — must be one of: #{VALID_NETWORKS.join(", ")}"
+    end
+
+    def resolve_network_value
+      return @network if @network_explicit && @network.is_a?(String) && !@network.empty?
+
+      env_val = ENV.fetch("BSV_NETWORK", nil)
+      return env_val if env_val.is_a?(String) && !env_val.empty?
+
+      DEFAULT_NETWORK
+    end
 
     # Resolve and announce the status endpoint token. Auto-generates a
     # random token if none was provided so the endpoint is always

--- a/spec/x402/configuration_spec.rb
+++ b/spec/x402/configuration_spec.rb
@@ -143,6 +143,66 @@ RSpec.describe X402::Configuration do
       expect { config.validate! }.to raise_error(X402::ConfigurationError, /domain/)
     end
 
+    context "network" do
+      around do |example|
+        original = ENV.fetch("BSV_NETWORK", nil)
+        ENV.delete("BSV_NETWORK")
+        example.run
+        ENV["BSV_NETWORK"] = original if original
+      end
+
+      it "defaults to bsv:mainnet" do
+        valid_config(config)
+        config.validate!
+        expect(config.network).to eq("bsv:mainnet")
+      end
+
+      it "accepts an explicit network override" do
+        valid_config(config)
+        config.network = "bsv:testnet"
+        config.validate!
+        expect(config.network).to eq("bsv:testnet")
+      end
+
+      it "respects BSV_NETWORK env var when network is not explicitly set" do
+        ENV["BSV_NETWORK"] = "bsv:testnet"
+        valid_config(config)
+        config.validate!
+        expect(config.network).to eq("bsv:testnet")
+      end
+
+      it "explicit config.network wins over BSV_NETWORK env var" do
+        ENV["BSV_NETWORK"] = "bsv:testnet"
+        valid_config(config)
+        config.network = "bsv:mainnet"
+        config.validate!
+        expect(config.network).to eq("bsv:mainnet")
+      end
+
+      it "raises on invalid network" do
+        valid_config(config)
+        config.network = "bsv:bogus"
+        expect { config.validate! }.to raise_error(
+          X402::ConfigurationError, /invalid network.*bsv:bogus.*bsv:mainnet, bsv:testnet/
+        )
+      end
+
+      it "raises on invalid BSV_NETWORK env var" do
+        ENV["BSV_NETWORK"] = "ethereum"
+        valid_config(config)
+        expect { config.validate! }.to raise_error(
+          X402::ConfigurationError, /invalid network.*ethereum/
+        )
+      end
+
+      it "treats blank BSV_NETWORK as unset (falls back to default)" do
+        ENV["BSV_NETWORK"] = ""
+        valid_config(config)
+        config.validate!
+        expect(config.network).to eq("bsv:mainnet")
+      end
+    end
+
     it "raises when neither wallet, server_wif nor payee_locking_script_hex is set" do
       config.domain = "example.com"
       config.gateways = [mock_gateway]


### PR DESCRIPTION
## Summary

- Replace hardcoded `NETWORK = "bsv:mainnet"` constants in all four gateways with `X402.configuration.network`
- New `config.network` attribute with resolution: explicit > `BSV_NETWORK` env var > `"bsv:mainnet"` default
- `validate!` raises on invalid values (must be `bsv:mainnet` or `bsv:testnet`)
- ProofGateway's inline `"bsv:mainnet"` string also replaced

## Test plan

- [x] `bundle exec rake` — 364 examples, 0 failures, 63 files inspected, no offences
- [x] 7 new configuration specs: default, explicit override, env var, precedence, invalid rejection, blank env fallback

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)