### PR TITLE
fix(security): resolve remaining v0.4.0 audit findings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     x402-rack (0.7.0)
       base64 (~> 0.2)
-      bsv-sdk (~> 0.4)
-      bsv-wallet (~> 0.2)
+      bsv-sdk (>= 0.9.0, < 1.0)
+      bsv-wallet (>= 0.5.0, < 1.0)
       json-canonicalization (~> 1.0)
       rack (~> 3.0)
 

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -169,9 +169,9 @@ module X402
       end
 
       def verify_binding!(transaction, rack_request)
-        expected_hex = "006a047834303220#{request_binding_hash(rack_request).unpack1("H*")}"
+        expected_script = build_op_return_script(request_binding_hash(rack_request))
         found = transaction.outputs.any? do |output|
-          output.locking_script.op_return? && output.locking_script.to_hex == expected_hex
+          output.locking_script.op_return? && output.locking_script.to_hex == expected_script.to_hex
         end
 
         return if found

--- a/lib/x402/bsv/proof_gateway.rb
+++ b/lib/x402/bsv/proof_gateway.rb
@@ -206,8 +206,10 @@ module X402
       end
 
       def decode_transaction(proof)
-        raw = Base64.decode64(proof.rawtx_b64)
+        raw = Base64.strict_decode64(proof.rawtx_b64)
         ::BSV::Transaction::Transaction.from_binary(raw)
+      rescue ArgumentError
+        raise VerificationError, "invalid base64 in transaction"
       rescue VerificationError
         raise
       rescue StandardError

--- a/x402-rack.gemspec
+++ b/x402-rack.gemspec
@@ -33,8 +33,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "base64", "~> 0.2"
-  spec.add_dependency "bsv-sdk", "~> 0.4"
-  spec.add_dependency "bsv-wallet", "~> 0.2"
+  spec.add_dependency "bsv-sdk", ">= 0.9.0", "< 1.0"
+  spec.add_dependency "bsv-wallet", ">= 0.5.0", "< 1.0"
   spec.add_dependency "json-canonicalization", "~> 1.0"
   spec.add_dependency "rack", "~> 3.0"
 end


### PR DESCRIPTION
## Summary

- **L-2**: ProofGateway `Base64.decode64` → `strict_decode64` (consistency with all other gateways)
- **L-4**: PayGateway `verify_binding!` uses `build_op_return_script` instead of duplicated hex interpolation
- **L-9**: Gemspec constraints tightened — `bsv-sdk >= 0.9.0`, `bsv-wallet >= 0.5.0`

This resolves all remaining actionable findings from the v0.4.0 security audit (#74).

## Test plan

- [x] `bundle exec rake` — 364 examples, 0 failures, 63 files inspected, no offences

Refs #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)