### PR TITLE
fix: BEEF internalisation for PayGateway wallet relay

### DIFF
--- a/lib/x402/bsv/gateway.rb
+++ b/lib/x402/bsv/gateway.rb
@@ -93,8 +93,8 @@ module X402
       # PayGateway uses one output per payment. The wallet can later derive
       # the matching private key using the same prefix/suffix pair.
       def derive_unique_payee_hex
-        prefix = SecureRandom.hex(16)
-        suffix = "0"
+        prefix = Base64.strict_encode64(SecureRandom.random_bytes(16))
+        suffix = Base64.strict_encode64("0")
         key_id = "#{prefix} #{suffix}"
         result = @wallet.get_public_key({
                                           protocol_id: BRC29_PROTOCOL_ID,

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -76,11 +76,12 @@ module X402
         suffix = payload.dig("accepted", "extra", "derivationSuffix")
         verify_pay_to_signature!(accepted_payee, pay_to_sig, prefix, suffix)
         transaction = decode_transaction(payload)
+        beef_b64 = payload.dig("payload", "beef")
         check_txid_unique!(transaction)
         verify_payment_output!(transaction, required_sats, accepted_payee)
         verify_binding!(transaction, rack_request)
         settle_transaction!(transaction, route)
-        relay_to_wallet(transaction, prefix, suffix)
+        relay_to_wallet(transaction, prefix, suffix, beef_b64)
         build_settlement_result(transaction)
       end
 
@@ -216,11 +217,11 @@ module X402
       # Relay the settled transaction to the operator's wallet for tracking.
       # This is a notification, not a gate — if it fails, the payment has
       # already landed on-chain via ARC and settlement proceeds normally.
-      def relay_to_wallet(transaction, prefix, suffix)
+      def relay_to_wallet(transaction, prefix, suffix, beef_b64 = nil)
         return unless @wallet
         return unless prefix
 
-        internalize_payment!(transaction, prefix, suffix)
+        internalize_payment!(transaction, prefix, suffix, beef_b64)
       rescue StandardError => e
         logger.warn "[pay-gateway] wallet internalisation failed (non-fatal): #{e.class}: #{e.message}"
       end
@@ -228,10 +229,18 @@ module X402
       # Output 0 is always the payment output — built by build_template.
       # The sender_identity_key is the wallet's own identity key because
       # derive_unique_payee_hex uses forSelf derivation (no counterparty).
-      def internalize_payment!(transaction, prefix, suffix)
+      #
+      # When the client includes BEEF (BRC-62) in payload.beef, those bytes
+      # are passed directly to internalize_action. Without BEEF, falls back
+      # to raw tx bytes (which most BRC-100 wallets will reject).
+      def internalize_payment!(transaction, prefix, suffix, beef_b64 = nil)
         identity = @wallet.get_public_key({ identity_key: true })
         sender_key = identity[:public_key] || identity["public_key"]
-        tx_bytes = transaction.to_binary.unpack("C*")
+        tx_bytes = if beef_b64
+                     Base64.strict_decode64(beef_b64).unpack("C*")
+                   else
+                     transaction.to_binary.unpack("C*")
+                   end
         @wallet.internalize_action(
           tx: tx_bytes,
           outputs: [{

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -226,7 +226,11 @@ module X402
       end
 
       # Output 0 is always the payment output — built by build_template.
+      # The sender_identity_key is the wallet's own identity key because
+      # derive_unique_payee_hex uses forSelf derivation (no counterparty).
       def internalize_payment!(transaction, prefix, suffix)
+        identity = @wallet.get_public_key({ identity_key: true })
+        sender_key = identity[:public_key] || identity["public_key"]
         tx_bytes = transaction.to_binary.unpack("C*")
         @wallet.internalize_action(
           tx: tx_bytes,
@@ -236,7 +240,7 @@ module X402
             payment_remittance: {
               derivation_prefix: prefix,
               derivation_suffix: suffix,
-              sender_identity_key: "anyone"
+              sender_identity_key: sender_key
             }
           }],
           description: "PayGateway payment"

--- a/lib/x402/remote_wallet.rb
+++ b/lib/x402/remote_wallet.rb
@@ -36,16 +36,18 @@ module X402
     # (cached after first call). Otherwise, delegates to the remote wallet
     # for BRC-42/43 key derivation.
     #
-    # @param identity_key [Boolean] whether to return the identity key
-    # @param protocol_id [Array, nil] BRC-43 protocol ID for derivation
-    # @param key_id [String, nil] key identifier for derivation
-    # @param counterparty [String, nil] counterparty identity key
+    # Matches ProtoWallet interface: accepts a positional Hash of arguments.
+    # Also supports keyword arguments for convenience (used by tests and
+    # direct callers).
+    #
+    # @param args [Hash] arguments hash (ProtoWallet style)
     # @return [Hash] +{ public_key: "hex" }+
-    def get_public_key(identity_key: false, protocol_id: nil, key_id: nil, counterparty: nil, **_rest)
-      if identity_key
+    def get_public_key(args = {}, **kwargs)
+      args = kwargs unless kwargs.empty?
+      if args[:identity_key]
         fetch_identity_key
       else
-        fetch_derived_key(protocol_id: protocol_id, key_id: key_id, counterparty: counterparty)
+        fetch_derived_key(protocol_id: args[:protocol_id], key_id: args[:key_id], counterparty: args[:counterparty])
       end
     end
 

--- a/spec/e2e/e2e_helper.rb
+++ b/spec/e2e/e2e_helper.rb
@@ -48,17 +48,30 @@ module E2EHelper
     JSON.parse(Base64.strict_decode64(header))
   end
 
-  # Build a Payment-Signature payload from a signed transaction
+  # Build a Payment-Signature payload from a signed transaction.
+  # Includes BEEF (BRC-62) when the transaction has source data available,
+  # enabling wallet internalisation on the server side.
   def self.build_payment_signature(challenge, transaction)
     accept = challenge["accepts"].first
+
+    payload_inner = {
+      "rawtx" => transaction.to_binary.unpack1("H*"),
+      "txid" => transaction.txid_hex
+    }
+
+    # Include BEEF when possible — BRC-100 wallets need it for internalisation
+    begin
+      beef = BSV::Transaction::Beef.new
+      beef.merge_transaction(transaction)
+      payload_inner["beef"] = Base64.strict_encode64(beef.to_atomic_binary(transaction.txid))
+    rescue StandardError
+      # Source transactions unavailable — send without BEEF
+    end
 
     payload = {
       "x402Version" => 2,
       "accepted" => accept,
-      "payload" => {
-        "rawtx" => transaction.to_binary.unpack1("H*"),
-        "txid" => transaction.txid_hex
-      }
+      "payload" => payload_inner
     }
 
     Base64.strict_encode64(JSON.generate(payload))

--- a/spec/e2e/fixtures/wallet-server.mjs
+++ b/spec/e2e/fixtures/wallet-server.mjs
@@ -21,7 +21,6 @@
 
 import http from 'node:http'
 import { URL } from 'node:url'
-import { Beef } from '@bsv/sdk'
 import { ServerWallet, createServerWalletHandler } from '@bsv/simple/server'
 
 const port = parseInt(process.env.WALLET_PORT || '9494', 10)
@@ -99,26 +98,18 @@ const server = http.createServer(async (req, res) => {
       }
     }
 
-    // Custom receive action — wraps raw tx bytes in BEEF for internalizeAction
+    // Custom receive action — passes BEEF bytes through to internalizeAction.
+    // The client is expected to send BEEF (BRC-62) in the tx field.
     if (req.method === 'POST' && action === 'receive') {
-      console.error('>>> Custom receive handler entered')
       try {
         let body = ''
         for await (const chunk of req) body += chunk
-        console.error('>>> Body length:', body.length)
         const payment = JSON.parse(body)
 
-        // Wrap raw tx bytes in BEEF for internalizeAction.
-        // The @bsv/sdk expects BEEF format, not raw transaction bytes.
-        const beef = new Beef()
-        beef.mergeRawTx(Uint8Array.from(payment.tx))
-        const beefBytes = Array.from(beef.toBinary())
-
         await client.internalizeAction({
-          tx: beefBytes,
-          tx: beefBytes,
+          tx: payment.tx,
           outputs: [{
-            outputIndex: payment.outputIndex,
+            outputIndex: payment.outputIndex ?? 0,
             protocol: 'wallet payment',
             paymentRemittance: {
               senderIdentityKey: payment.senderIdentityKey,

--- a/spec/e2e/fixtures/wallet-server.mjs
+++ b/spec/e2e/fixtures/wallet-server.mjs
@@ -21,6 +21,7 @@
 
 import http from 'node:http'
 import { URL } from 'node:url'
+import { Beef } from '@bsv/sdk'
 import { ServerWallet, createServerWalletHandler } from '@bsv/simple/server'
 
 const port = parseInt(process.env.WALLET_PORT || '9494', 10)
@@ -95,6 +96,42 @@ const server = http.createServer(async (req, res) => {
       } catch (err) {
         console.error('getPublicKey error:', err.message)
         return jsonResponse(res, 500, { error: err.message })
+      }
+    }
+
+    // Custom receive action — wraps raw tx bytes in BEEF for internalizeAction
+    if (req.method === 'POST' && action === 'receive') {
+      console.error('>>> Custom receive handler entered')
+      try {
+        let body = ''
+        for await (const chunk of req) body += chunk
+        console.error('>>> Body length:', body.length)
+        const payment = JSON.parse(body)
+
+        // Wrap raw tx bytes in BEEF for internalizeAction.
+        // The @bsv/sdk expects BEEF format, not raw transaction bytes.
+        const beef = new Beef()
+        beef.mergeRawTx(Uint8Array.from(payment.tx))
+        const beefBytes = Array.from(beef.toBinary())
+
+        await client.internalizeAction({
+          tx: beefBytes,
+          tx: beefBytes,
+          outputs: [{
+            outputIndex: payment.outputIndex,
+            protocol: 'wallet payment',
+            paymentRemittance: {
+              senderIdentityKey: payment.senderIdentityKey,
+              derivationPrefix: payment.derivationPrefix,
+              derivationSuffix: payment.derivationSuffix
+            }
+          }],
+          description: payment.description || 'PayGateway payment'
+        })
+        return jsonResponse(res, 200, { success: true })
+      } catch (err) {
+        console.error('receive error:', err.message)
+        return jsonResponse(res, 500, { success: false, error: `receive failed: ${err.message}` })
       }
     }
 

--- a/spec/x402/bsv/pay_gateway_spec.rb
+++ b/spec/x402/bsv/pay_gateway_spec.rb
@@ -450,8 +450,8 @@ RSpec.describe X402::BSV::PayGateway do
         remittance = output[:payment_remittance]
         expect(remittance[:derivation_prefix]).to be_a(String)
         expect(remittance[:derivation_prefix]).not_to be_empty
-        expect(remittance[:derivation_suffix]).to eq("0")
-        expect(remittance[:sender_identity_key]).to eq("anyone")
+        expect(remittance[:derivation_suffix]).to eq(Base64.strict_encode64("0"))
+        expect(remittance[:sender_identity_key]).to match(/\A[0-9a-f]{66}\z/)
       end
 
       it "succeeds even when internalize_action raises" do
@@ -474,7 +474,7 @@ RSpec.describe X402::BSV::PayGateway do
         expect(extra).to have_key("derivationPrefix")
         expect(extra["derivationPrefix"]).to be_a(String)
         expect(extra["derivationPrefix"]).not_to be_empty
-        expect(extra["derivationSuffix"]).to eq("0")
+        expect(extra["derivationSuffix"]).to eq(Base64.strict_encode64("0"))
       end
 
       it "does not include derivation params in challenge extra without wallet" do

--- a/spec/x402/bsv/pay_gateway_spec.rb
+++ b/spec/x402/bsv/pay_gateway_spec.rb
@@ -405,12 +405,17 @@ RSpec.describe X402::BSV::PayGateway do
                        unlocking_script: BSV::Script::Script.new("\x00".b)
                      ))
 
+        beef = BSV::Transaction::Beef.new
+        beef.merge_transaction(tx)
+        beef_b64 = Base64.strict_encode64(beef.to_atomic_binary(tx.txid))
+
         payload = {
           "x402Version" => 2,
           "accepted" => accepted,
           "payload" => {
             "rawtx" => tx.to_binary.unpack1("H*"),
-            "txid" => tx.txid_hex
+            "txid" => tx.txid_hex,
+            "beef" => beef_b64
           }
         }
 
@@ -443,6 +448,9 @@ RSpec.describe X402::BSV::PayGateway do
         expect(received_args).not_to be_nil
         expect(received_args[:description]).to eq("PayGateway payment")
         expect(received_args[:tx]).to be_an(Array)
+        # tx bytes should be AtomicBEEF (BRC-95), not raw tx
+        beef_hex = received_args[:tx].pack("C*").unpack1("H*")
+        expect(beef_hex).to include("beef")
 
         output = received_args[:outputs].first
         expect(output[:output_index]).to eq(0)


### PR DESCRIPTION
## Summary

- **PayGateway** accepts optional `payload.beef` (base64 AtomicBEEF) from the Coinbase v2 payment envelope and passes it to `internalize_action` — BRC-100 wallets require BEEF, not raw tx bytes
- **RemoteWallet#get_public_key** fixed to match ProtoWallet positional Hash interface
- **Derivation params** base64-encoded (prefix/suffix), identity key used for `sender_identity_key`
- **Wallet-server fixture** simplified to pass BEEF through (no more `mergeRawTx` wrapping)

### Root cause

`@bsv/sdk`'s `internalizeAction` validates `tx` via `Beef.fromBinary()`, which expects BRC-62 BEEF format — not raw transaction bytes. The client (via BRC-100 wallet `createAction`) already has AtomicBEEF available; it just needs to send it.

### Commits

1. `c71509c` — `RemoteWallet#get_public_key` calling convention (positional Hash)
2. `9b2d718` — base64 derivation params, identity key, wallet-server receive handler
3. `793db4f` — accept BEEF from client, pass to `internalize_action`

### Coordination

- **sgbett/bsv-x402#102** (merged) — client now sends `{ txid, beef }` instead of `{ txid, rawTx }`
- **#135** — separate issue for ProofGateway to accept BEEF from `X402-Proof` header

## Test plan

- [x] 404 RSpec examples, 0 failures
- [x] RuboCop clean
- [x] Unit test asserts AtomicBEEF magic bytes in `internalize_action` tx
- [ ] E2E with `CLIENT_WIF` — wallet balance increases after payment

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)