### PR TITLE
fix: internalize_action kwargs → positional Hash

### DIFF
--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -203,19 +203,19 @@ module X402
       def internalize_payment!(transaction_b64:, output_index:, derivation_prefix:, derivation_suffix:,
                                sender_identity_key:)
         tx_bytes = Base64.strict_decode64(transaction_b64).unpack("C*")
-        @wallet.internalize_action(
-          tx: tx_bytes,
-          outputs: [{
-            output_index: output_index,
-            protocol: PROTOCOL,
-            payment_remittance: {
-              derivation_prefix: derivation_prefix,
-              derivation_suffix: derivation_suffix,
-              sender_identity_key: sender_identity_key
-            }
-          }],
-          description: "BRC-105 payment"
-        )
+        @wallet.internalize_action({
+                                     tx: tx_bytes,
+                                     outputs: [{
+                                       output_index: output_index,
+                                       protocol: PROTOCOL,
+                                       payment_remittance: {
+                                         derivation_prefix: derivation_prefix,
+                                         derivation_suffix: derivation_suffix,
+                                         sender_identity_key: sender_identity_key
+                                       }
+                                     }],
+                                     description: "BRC-105 payment"
+                                   })
       rescue VerificationError
         raise
       rescue StandardError => e

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -227,19 +227,19 @@ module X402
 
       def internalize_payment!(beef_b64:, output_index:, derivation_prefix:, derivation_suffix:, sender_identity_key:)
         tx_bytes = Base64.strict_decode64(beef_b64).unpack("C*")
-        @wallet.internalize_action(
-          tx: tx_bytes,
-          outputs: [{
-            output_index: output_index,
-            protocol: PROTOCOL,
-            payment_remittance: {
-              derivation_prefix: derivation_prefix,
-              derivation_suffix: derivation_suffix,
-              sender_identity_key: sender_identity_key
-            }
-          }],
-          description: "BRC-121 payment"
-        )
+        @wallet.internalize_action({
+                                     tx: tx_bytes,
+                                     outputs: [{
+                                       output_index: output_index,
+                                       protocol: PROTOCOL,
+                                       payment_remittance: {
+                                         derivation_prefix: derivation_prefix,
+                                         derivation_suffix: derivation_suffix,
+                                         sender_identity_key: sender_identity_key
+                                       }
+                                     }],
+                                     description: "BRC-121 payment"
+                                   })
       rescue VerificationError
         raise
       rescue StandardError => e

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -241,19 +241,19 @@ module X402
                    else
                      transaction.to_binary.unpack("C*")
                    end
-        @wallet.internalize_action(
-          tx: tx_bytes,
-          outputs: [{
-            output_index: 0,
-            protocol: "wallet payment",
-            payment_remittance: {
-              derivation_prefix: prefix,
-              derivation_suffix: suffix,
-              sender_identity_key: sender_key
-            }
-          }],
-          description: "PayGateway payment"
-        )
+        @wallet.internalize_action({
+                                     tx: tx_bytes,
+                                     outputs: [{
+                                       output_index: 0,
+                                       protocol: "wallet payment",
+                                       payment_remittance: {
+                                         derivation_prefix: prefix,
+                                         derivation_suffix: suffix,
+                                         sender_identity_key: sender_key
+                                       }
+                                     }],
+                                     description: "PayGateway payment"
+                                   })
       end
 
       def build_settlement_result(transaction)

--- a/lib/x402/remote_wallet.rb
+++ b/lib/x402/remote_wallet.rb
@@ -53,17 +53,19 @@ module X402
 
     # Relay a settled payment to the remote wallet for internalisation.
     #
-    # @param tx [Array<Integer>] transaction bytes
-    # @param outputs [Array<Hash>] output descriptors with derivation metadata
-    # @param description [String] human-readable description
+    # Matches ProtoWallet interface: accepts a positional Hash of arguments.
+    # Also supports keyword arguments for convenience.
+    #
+    # @param args [Hash] arguments hash (ProtoWallet style)
     # @return [Hash] the wallet's response
-    def internalize_action(tx:, outputs:, description: "") # rubocop:disable Naming/MethodParameterName
-      output = outputs.first || {}
+    def internalize_action(args = {}, **kwargs)
+      args = kwargs unless kwargs.empty?
+      output = args[:outputs]&.first || {}
       remittance = output[:payment_remittance] || {}
 
       body = {
-        tx: tx,
-        description: description,
+        tx: args[:tx],
+        description: args[:description] || "",
         senderIdentityKey: remittance[:sender_identity_key],
         derivationPrefix: remittance[:derivation_prefix],
         derivationSuffix: remittance[:derivation_suffix],

--- a/spec/x402/bsv/brc105_gateway_spec.rb
+++ b/spec/x402/bsv/brc105_gateway_spec.rb
@@ -216,19 +216,19 @@ RSpec.describe X402::BSV::BRC105Gateway do
 
         real_gateway.settle!("x-bsv-payment", payload, request, route)
 
-        expect(wallet).to have_received(:internalize_action).with(
-          tx: an_instance_of(Array),
-          outputs: [hash_including(
-            output_index: 0,
-            protocol: "wallet payment",
-            payment_remittance: {
-              derivation_prefix: prefix,
-              derivation_suffix: suffix,
-              sender_identity_key: client_identity_key
-            }
-          )],
-          description: "BRC-105 payment"
-        )
+        expect(wallet).to have_received(:internalize_action).with(hash_including(
+                                                                    tx: an_instance_of(Array),
+                                                                    outputs: [hash_including(
+                                                                      output_index: 0,
+                                                                      protocol: "wallet payment",
+                                                                      payment_remittance: {
+                                                                        derivation_prefix: prefix,
+                                                                        derivation_suffix: suffix,
+                                                                        sender_identity_key: client_identity_key
+                                                                      }
+                                                                    )],
+                                                                    description: "BRC-105 payment"
+                                                                  ))
       end
     end
 

--- a/spec/x402/bsv/pay_gateway_spec.rb
+++ b/spec/x402/bsv/pay_gateway_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe X402::BSV::PayGateway do
           privkey = BSV::Primitives::PrivateKey.generate
           { public_key: privkey.public_key.to_hex }
         end
-        wallet.define_singleton_method(:internalize_action) do |**_kwargs|
+        wallet.define_singleton_method(:internalize_action) do |_args = {}|
           { "accepted" => true }
         end
         wallet
@@ -424,7 +424,7 @@ RSpec.describe X402::BSV::PayGateway do
 
       it "calls wallet.internalize_action after broadcast when wallet is present" do
         called = false
-        mock_wallet.define_singleton_method(:internalize_action) do |**_kwargs|
+        mock_wallet.define_singleton_method(:internalize_action) do |_args = {}|
           called = true
           { "accepted" => true }
         end
@@ -437,8 +437,8 @@ RSpec.describe X402::BSV::PayGateway do
 
       it "passes correct BRC-29 derivation params to internalize_action" do
         received_args = nil
-        mock_wallet.define_singleton_method(:internalize_action) do |**kwargs|
-          received_args = kwargs
+        mock_wallet.define_singleton_method(:internalize_action) do |args = {}|
+          received_args = args
           { "accepted" => true }
         end
 
@@ -463,7 +463,7 @@ RSpec.describe X402::BSV::PayGateway do
       end
 
       it "succeeds even when internalize_action raises" do
-        mock_wallet.define_singleton_method(:internalize_action) do |**_kwargs|
+        mock_wallet.define_singleton_method(:internalize_action) do |_args = {}|
           raise "wallet unreachable"
         end
 

--- a/spec/x402/remote_wallet_spec.rb
+++ b/spec/x402/remote_wallet_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe X402::RemoteWallet do
       expect(captured_body["outputIndex"]).to eq(0)
     end
 
+    it "accepts a positional Hash (ProtoWallet convention)" do
+      result = wallet.internalize_action({
+                                           tx: tx_bytes,
+                                           outputs: [{
+                                             output_index: 0,
+                                             protocol: "wallet payment",
+                                             payment_remittance: {
+                                               derivation_prefix: "cHJlZml4",
+                                               derivation_suffix: "c3VmZml4",
+                                               sender_identity_key: sender_key
+                                             }
+                                           }],
+                                           description: "BRC-121 payment"
+                                         })
+
+      expect(result).to eq("accepted" => true)
+      expect(captured_body["tx"]).to eq(tx_bytes)
+      expect(captured_body["senderIdentityKey"]).to eq(sender_key)
+    end
+
     context "when outputs is empty" do
       it "posts with nil derivation fields" do
         result = wallet.internalize_action(tx: tx_bytes, outputs: [], description: "test")


### PR DESCRIPTION
## Summary

- All three gateways (BRC105, BRC121, PayGateway) now call `wallet.internalize_action({...})` with a positional Hash instead of kwargs
- `RemoteWallet#internalize_action` updated to accept either form (positional Hash or kwargs)
- New test for positional Hash calling convention on RemoteWallet

### Root cause

`WalletClient#internalize_action` (bsv-wallet gem) accepts `(args, _originator: nil)` — a positional Hash. Ruby kwargs don't match this signature, causing `ArgumentError: wrong number of arguments (given 0, expected 1)`.

Same class of bug as the `get_public_key` fix in #136.

## Test plan

- [x] 405 RSpec examples, 0 failures
- [x] RuboCop clean
- [x] New test: RemoteWallet accepts positional Hash

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)