### PR TITLE
fix: replace TAAL ARC URLs with ARCADE

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ end
 use X402::Middleware
 ```
 
-ARC defaults to GorillaPool Arcade. The server holds no private keys — it derives unique payment addresses from the remote wallet's public key, broadcasts via ARC, then relays the settlement to the wallet for UTXO tracking.
+ARC defaults to ARCADE. The server holds no private keys — it derives unique payment addresses from the remote wallet's public key, broadcasts via ARC, then relays the settlement to the wallet for UTXO tracking.
 
 ### With a local wallet (enables BRC-121)
 
@@ -60,7 +60,7 @@ end
 use X402::Middleware
 ```
 
-Both PayGateway and BRC121Gateway are auto-enabled. ARC defaults to GorillaPool Arcade.
+Both PayGateway and BRC121Gateway are auto-enabled. ARC defaults to ARCADE.
 
 ### With a remote wallet for all gateways
 
@@ -93,7 +93,7 @@ Clients can pay using whichever protocol they support; the middleware dispatches
 | `BRC105Gateway` (BRC-105) | Yes (local or remote) | `config.enable :brc105_gateway` | Transitional |
 | `ProofGateway` (merkleworks) | No | `config.enable :proof_gateway` | Experimental |
 
-PayGateway is the only gateway that works without a wallet — it derives payment addresses from the operator's public key and relays settlement after broadcast. BRC-121 and BRC-105 require a wallet for `internalize_action`. ARC defaults to GorillaPool Arcade when no explicit `arc_url` is configured.
+PayGateway is the only gateway that works without a wallet — it derives payment addresses from the operator's public key and relays settlement after broadcast. BRC-121 and BRC-105 require a wallet for `internalize_action`. ARC defaults to ARCADE when no explicit `arc_url` is configured.
 
 ## Advanced configuration
 
@@ -159,7 +159,7 @@ Backwards-compat alternatives still work: `config.server_wif = ENV["SERVER_WIF"]
 
 Four BSV settlement schemes are supported:
 
-- **BSV-pay** (Coinbase v2 headers) — server broadcasts via ARC (defaults to GorillaPool Arcade). Partial transaction template, unique derived addresses per payment. Works without a wallet via `operator_wallet_url`.
+- **BSV-pay** (Coinbase v2 headers) — server broadcasts via ARC (defaults to ARCADE). Partial transaction template, unique derived addresses per payment. Works without a wallet via `operator_wallet_url`.
 - **BRC-121** (BSV Association simple) — stateless, BRC-100 wallet-native, zero config.
 - **BRC-105** (BSV Association authenticated) — settlement via `wallet.internalize_action`. Transitional; requires BRC-103 for spec compliance.
 - **BSV-proof** (merkleworks) — experimental; client broadcasts, server checks mempool.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -56,7 +56,7 @@ These namespaces must not overlap. When designing new headers or gateway types, 
 
 **x402-rack is a payment gate, not a wallet.** It verifies payments, broadcasts when required, and relays settlement events to the operator's wallet. It should never hold funds or require private key material on the server.
 
-**PayGateway** implements the Coinbase v2 header spec with BSV as the settlement network — BSV as a first-class citizen in the broader x402 ecosystem. It is the only gateway that works without a wallet: `operator_wallet_url` enables a keyless relay mode where the server derives unique payment addresses from the remote wallet's public key, broadcasts via ARC (defaulting to GorillaPool Arcade), and relays settlement to the wallet for UTXO tracking. With a wallet, PayGateway converges to the same `internalize_action` settlement engine as BRC-121 and BRC-105.
+**PayGateway** implements the Coinbase v2 header spec with BSV as the settlement network — BSV as a first-class citizen in the broader x402 ecosystem. It is the only gateway that works without a wallet: `operator_wallet_url` enables a keyless relay mode where the server derives unique payment addresses from the remote wallet's public key, broadcasts via ARC (defaulting to ARCADE), and relays settlement to the wallet for UTXO tracking. With a wallet, PayGateway converges to the same `internalize_action` settlement engine as BRC-121 and BRC-105.
 
 **BRC121Gateway** implements the BSV Association's simple HTTP payment protocol — stateless, BRC-100 wallet-native, zero config. The most direct path to a working BSV-native x402 server.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ end
 use X402::Middleware
 ```
 
-PayGateway is auto-enabled. ARC defaults to GorillaPool Arcade. The server holds no private keys.
+PayGateway is auto-enabled. ARC defaults to ARCADE. The server holds no private keys.
 
 ### With a local wallet (enables BRC-121)
 
@@ -56,7 +56,7 @@ end
 use X402::Middleware
 ```
 
-Both PayGateway and BRC121Gateway are auto-enabled. ARC defaults to GorillaPool Arcade.
+Both PayGateway and BRC121Gateway are auto-enabled. ARC defaults to ARCADE.
 
 ### With a remote wallet for all gateways
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -13,7 +13,7 @@ X402.configure do |config|
 
   config.gateways = [
     X402::BSV::PayGateway.new(
-      arc_client: BSV::Network::ARC.new("https://arc.taal.com", api_key: "..."),
+      arc_client: BSV::Network::ARC.new("https://arcade.gorillapool.io", api_key: "..."),
       payee_locking_script_hex: "76a914...88ac"
     )
   ]
@@ -30,14 +30,13 @@ Both gateways need an ARC endpoint. The `bsv-sdk` provides `BSV::Network::ARC`:
 
 ```ruby
 arc = BSV::Network::ARC.new(
-  "https://arc.taal.com",
+  "https://arcade.gorillapool.io",
   api_key: "your-api-key"
 )
 ```
 
-- **Testnet**: `https://arc-test.taal.com`
-- **Mainnet**: `https://arc.taal.com`
-- **API key**: free for low volume at https://console.taal.com
+- **Testnet**: `https://testnet.arcade.gorillapool.io`
+- **Mainnet**: `https://arcade.gorillapool.io`
 
 ## Rate Limiting
 
@@ -90,5 +89,5 @@ arc = BSV::Network::ARC.new(
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `ARC_URL` | Yes | ARC broadcast endpoint |
-| `ARC_API_KEY` | TAAL requires it | TAAL ARC API key |
+| `ARC_API_KEY` | Optional | ARCADE API key (if required by provider) |
 | `PAYEE_SCRIPT` | Yes | Payee locking script hex |

--- a/docs/operations/performance.md
+++ b/docs/operations/performance.md
@@ -71,7 +71,7 @@ For high-traffic PayGateway deployments, consider HTTP connection pooling to ARC
 ```ruby
 # Use a persistent HTTP client
 http_client = Net::HTTP::Persistent.new
-arc = BSV::Network::ARC.new("https://arc.taal.com",
+arc = BSV::Network::ARC.new("https://arcade.gorillapool.io",
                             api_key: "...",
                             http_client: http_client)
 ```

--- a/docs/schemes/brc-121.md
+++ b/docs/schemes/brc-121.md
@@ -80,7 +80,7 @@ The minimal zero-config setup:
 X402.configure do |c|
   c.domain = "api.example.com"
   c.wallet = X402::Wallet.load       # reads ~/.bsv-wallet/wallet.key
-  c.arc_url = "https://arc.taal.com"
+  c.arc_url = "https://arcade.gorillapool.io"
   c.protect method: :GET, path: "/api/expensive", amount_sats: 100
 end
 

--- a/lib/x402/configuration.rb
+++ b/lib/x402/configuration.rb
@@ -6,12 +6,10 @@ require_relative "remote_wallet"
 module X402
   # DSL for configuring X402 middleware, gateways, and protected routes.
   #
-  # @example Minimal configuration
+  # @example Minimal configuration (relay mode — no keys on server)
   #   X402.configure do |config|
   #     config.domain = "api.example.com"
-  #     config.server_wif = ENV["SERVER_WIF"]
-  #     config.arc_url = "https://arc.taal.com"
-  #     config.enable :pay_gateway
+  #     config.operator_wallet_url = "https://my-wallet.example.com/api/server-wallet"
   #     config.protect method: :GET, path: "/api/expensive", amount_sats: 100
   #   end
   class Configuration
@@ -396,7 +394,7 @@ module X402
       enable(:pay_gateway) if arc_available?
     end
 
-    # Always true — ARC.default (GorillaPool Arcade) is available even
+    # Always true — ARC.default (ARCADE) is available even
     # when no explicit arc_url is configured. PayGateway is auto-enabled
     # whenever a wallet is present.
     def arc_available?
@@ -407,7 +405,7 @@ module X402
       if arc_url && !arc_url.empty?
         ::BSV::Network::ARC.new(arc_url, api_key: arc_api_key)
       else
-        logger.info "[x402] using default ARC broadcaster (GorillaPool Arcade)"
+        logger.info "[x402] using default ARC broadcaster (ARCADE)"
         ::BSV::Network::ARC.default(testnet: @network == "bsv:testnet")
       end
     end

--- a/lib/x402/middleware.rb
+++ b/lib/x402/middleware.rb
@@ -12,15 +12,10 @@ module X402
   # to the matching gateway for settlement.
   #
   # @example config.ru
-  #   X402.configure do |config|
-  #     config.domain = "api.example.com"
-  #     config.server_wif = ENV["SERVER_WIF"]
-  #     config.arc_url = "https://arc.taal.com"
-  #     config.enable :pay_gateway
-  #     config.protect method: :GET, path: "/api/expensive", amount_sats: 100
-  #   end
-  #
+  #   X402.configure { |c| c.operator_wallet_url = "https://..." }
   #   use X402::Middleware
+  #
+  # @see X402::Configuration for full configuration options
   class Middleware
     # @param app [#call] next Rack app in the middleware stack
     def initialize(app)

--- a/spec/e2e/brc105_gateway_e2e_spec.rb
+++ b/spec/e2e/brc105_gateway_e2e_spec.rb
@@ -5,7 +5,7 @@
 # Environment variables:
 #   SERVER_WIF       - server identity key in WIF format (testnet)
 #   CLIENT_WIF       - client wallet private key in WIF format (testnet)
-#   ARC_URL          - ARC endpoint (default: https://arc-test.taal.com)
+#   ARC_URL          - ARC endpoint (default: https://testnet.arcade.gorillapool.io)
 #   ARC_API_KEY      - ARC API key
 #
 # Two wallets:
@@ -26,7 +26,7 @@ require "bsv-wallet"
 RSpec.describe "BRC105Gateway e2e", :e2e do
   let(:server_wif) { ENV.fetch("SERVER_WIF") { skip "SERVER_WIF not set" } }
   let(:client_wif) { ENV.fetch("CLIENT_WIF") { skip "CLIENT_WIF not set" } }
-  let(:arc_url) { ENV.fetch("ARC_URL", "https://arc-test.taal.com") }
+  let(:arc_url) { ENV.fetch("ARC_URL", "https://testnet.arcade.gorillapool.io") }
   let(:arc_api_key) { ENV.fetch("ARC_API_KEY") { skip "ARC_API_KEY not set" } }
 
   let(:server_key) { BSV::Primitives::PrivateKey.from_wif(server_wif) }

--- a/spec/e2e/config.ru
+++ b/spec/e2e/config.ru
@@ -6,7 +6,7 @@
 #   rackup spec/e2e/config.ru -p 9292
 #
 # Environment variables:
-#   ARC_URL       - ARC endpoint (default: https://arc-test.taal.com)
+#   ARC_URL       - ARC endpoint (default: https://testnet.arcade.gorillapool.io)
 #   ARC_API_KEY   - ARC API key
 #   PAYEE_SCRIPT  - payee locking script hex (required)
 
@@ -14,7 +14,7 @@ require "bundler/setup"
 require "x402"
 require "x402/bsv"
 
-arc_url = ENV.fetch("ARC_URL", "https://arc-test.taal.com")
+arc_url = ENV.fetch("ARC_URL", "https://testnet.arcade.gorillapool.io")
 arc_api_key = ENV.fetch("ARC_API_KEY", nil)
 payee_script = ENV.fetch("PAYEE_SCRIPT") { raise "PAYEE_SCRIPT env var is required" }
 

--- a/spec/e2e/pay_gateway_e2e_spec.rb
+++ b/spec/e2e/pay_gateway_e2e_spec.rb
@@ -5,7 +5,7 @@
 # Environment variables:
 #   CLIENT_WIF       - client wallet private key in WIF format (testnet)
 #   PAYEE_SCRIPT     - payee locking script hex
-#   ARC_URL          - ARC endpoint (default: https://arc-test.taal.com)
+#   ARC_URL          - ARC endpoint (default: https://testnet.arcade.gorillapool.io)
 #   ARC_API_KEY      - ARC API key
 #
 # Run:
@@ -17,11 +17,11 @@ require_relative "e2e_logger"
 RSpec.describe "PayGateway e2e", :e2e do
   let(:client_wif) { ENV.fetch("CLIENT_WIF") { skip "CLIENT_WIF not set" } }
   let(:payee_script_hex) { ENV.fetch("PAYEE_SCRIPT") { skip "PAYEE_SCRIPT not set" } }
-  let(:arc_url) { ENV.fetch("ARC_URL", "https://arc-test.taal.com") }
+  let(:arc_url) { ENV.fetch("ARC_URL", "https://testnet.arcade.gorillapool.io") }
   let(:base_url) { "http://localhost:#{@port}" }
 
   before(:all) do
-    ENV["ARC_URL"] ||= "https://arc-test.taal.com"
+    ENV["ARC_URL"] ||= "https://testnet.arcade.gorillapool.io"
     ENV["PAYEE_SCRIPT"] ||= "76a914#{"00" * 20}88ac"
 
     @server, @thread, @port = E2EHelper.start_server(

--- a/spec/e2e/pay_gateway_relay_e2e_spec.rb
+++ b/spec/e2e/pay_gateway_relay_e2e_spec.rb
@@ -8,7 +8,7 @@
 #
 # Environment variables:
 #   CLIENT_WIF  - client wallet private key in WIF format (testnet)
-#   ARC_URL     - ARC endpoint (default: https://arc-test.taal.com)
+#   ARC_URL     - ARC endpoint (default: https://testnet.arcade.gorillapool.io)
 #   ARC_API_KEY - ARC API key
 #   WALLET_PORT - Node.js wallet port (default: 9494)
 #
@@ -59,7 +59,7 @@ RSpec.describe "PayGateway relay mode (e2e)", :e2e do
     skip "Node.js wallet server failed to start" unless wallet_ready
 
     # Set env vars before starting Rack — relay_config.ru reads them at boot
-    ENV["ARC_URL"] ||= "https://arc-test.taal.com"
+    ENV["ARC_URL"] ||= "https://testnet.arcade.gorillapool.io"
     ENV["OPERATOR_WALLET_URL"] = "http://localhost:#{@wallet_port}/api/server-wallet"
 
     @rack_server, @rack_thread, @rack_port = E2EHelper.start_server(

--- a/spec/e2e/proof_gateway_delegated_e2e_spec.rb
+++ b/spec/e2e/proof_gateway_delegated_e2e_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "ProofGateway e2e with fee delegation", :e2e do
   let(:client_wif) { ENV.fetch("CLIENT_WIF") { skip "CLIENT_WIF not set" } }
   let(:delegator_wif) { ENV.fetch("DELEGATOR_WIF") { skip "DELEGATOR_WIF not set" } }
   let(:payee_script_hex) { ENV.fetch("PAYEE_SCRIPT") { skip "PAYEE_SCRIPT not set" } }
-  let(:arc_url) { ENV.fetch("ARC_URL", "https://arc-test.taal.com") }
+  let(:arc_url) { ENV.fetch("ARC_URL", "https://testnet.arcade.gorillapool.io") }
   let(:arc_api_key) { ENV.fetch("ARC_API_KEY") { skip "ARC_API_KEY not set" } }
 
   let(:treasury_key) { BSV::Primitives::PrivateKey.from_wif(treasury_wif) }

--- a/spec/e2e/proof_gateway_e2e_spec.rb
+++ b/spec/e2e/proof_gateway_e2e_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "ProofGateway e2e (Profile B)", :e2e do
   let(:treasury_wif) { ENV.fetch("TREASURY_WIF") { skip "TREASURY_WIF not set" } }
   let(:client_wif) { ENV.fetch("CLIENT_WIF") { skip "CLIENT_WIF not set" } }
   let(:payee_script_hex) { ENV.fetch("PAYEE_SCRIPT") { skip "PAYEE_SCRIPT not set" } }
-  let(:arc_url) { ENV.fetch("ARC_URL", "https://arc-test.taal.com") }
+  let(:arc_url) { ENV.fetch("ARC_URL", "https://testnet.arcade.gorillapool.io") }
   let(:arc_api_key) { ENV.fetch("ARC_API_KEY") { skip "ARC_API_KEY not set" } }
 
   let(:treasury_key) { BSV::Primitives::PrivateKey.from_wif(treasury_wif) }


### PR DESCRIPTION
## Summary

- All ARC endpoint references updated from TAAL (`arc-test.taal.com`, `arc.taal.com`) to ARCADE (`arcade.gorillapool.io`, `testnet.arcade.gorillapool.io`)
- "GorillaPool Arcade" normalised to "ARCADE" throughout
- Duplicated config example removed from `middleware.rb` (now points to `Configuration`)
- Configuration example updated to use modern relay-mode setup (no hardcoded URL)

The runtime default (`ARC.default`) comes from the SDK — tracked in sgbett/bsv-ruby-sdk#418.

## Test plan

- [x] 405 RSpec examples, 0 failures
- [x] RuboCop clean
- [x] No remaining references to `taal.com` (except historical plan file)

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)