### PR TITLE
refactor: update status endpoint to use wallet abstraction

### DIFF
--- a/lib/x402/status_endpoint.rb
+++ b/lib/x402/status_endpoint.rb
@@ -3,7 +3,6 @@
 require "json"
 require "rack"
 require "bsv-sdk"
-require "bsv-wallet"
 
 module X402
   # Read-only HTTP status endpoint for the x402-rack middleware.
@@ -98,6 +97,12 @@ module X402
       wallet = config.shared_wallet
       return identity_missing unless wallet
 
+      # Lazy require — bsv-wallet may not be loaded yet if the wallet
+      # was constructed externally (e.g. RemoteWallet from operator_wallet_url).
+      require "bsv-wallet"
+
+      # Positional hash, not kwargs — ProtoWallet's signature is
+      # (args, originator:) and Ruby 3.4 strict separation breaks kwargs.
       result = wallet.get_public_key({ identity_key: true })
       hex = result.is_a?(Hash) ? (result[:public_key] || result["publicKey"]) : result
       address = ::BSV::Primitives::PublicKey.from_hex(hex).address

--- a/lib/x402/status_endpoint.rb
+++ b/lib/x402/status_endpoint.rb
@@ -3,6 +3,7 @@
 require "json"
 require "rack"
 require "bsv-sdk"
+require "bsv-wallet"
 
 module X402
   # Read-only HTTP status endpoint for the x402-rack middleware.
@@ -14,7 +15,7 @@ module X402
   #
   # @example Enable in configuration
   #   X402.configure do |c|
-  #     c.server_wif = ENV["SERVER_WIF"]
+  #     c.wallet = my_wallet  # any BRC-100 compatible wallet
   #     c.enable_status_endpoint
   #     # c.status_endpoint_token = ENV["X402_STATUS_TOKEN"] # explicit (recommended in prod)
   #     # c.status_endpoint_path  = "/_x402/status"          # default
@@ -85,39 +86,45 @@ module X402
       }
     end
 
+    # Resolves the server's identity (public key + address) via the
+    # shared wallet's +get_public_key(identity_key: true)+ interface.
+    #
+    # Returns a hash with +:public_key+, +:address+, and +:address_note+.
+    # Degrades gracefully when no wallet is configured or the wallet
+    # raises an error — never crashes the endpoint.
+    #
+    # @return [Hash]
     def identity_data
-      key, status = identity_private_key
-      case status
-      when :ok
-        {
-          public_key: key.public_key.to_hex,
-          address: key.public_key.address,
-          address_note: ADDRESS_NOTE
-        }
-      when :missing
-        {
-          public_key: nil,
-          address: nil,
-          address_note: "server_wif is not configured — no identity available."
-        }
-      when :invalid
-        {
-          public_key: nil,
-          address: nil,
-          address_note: "server_wif is set but failed to parse — check the configured value."
-        }
-      end
+      wallet = config.shared_wallet
+      return identity_missing unless wallet
+
+      result = wallet.get_public_key({ identity_key: true })
+      hex = result.is_a?(Hash) ? (result[:public_key] || result["publicKey"]) : result
+      address = ::BSV::Primitives::PublicKey.from_hex(hex).address
+
+      {
+        public_key: hex,
+        address: address,
+        address_note: ADDRESS_NOTE
+      }
+    rescue StandardError
+      identity_invalid
     end
 
-    # @return [Array(BSV::Primitives::PrivateKey, Symbol)] tuple of
-    #   parsed key (or nil) and status: +:ok+, +:missing+, or +:invalid+
-    def identity_private_key
-      wif = config.server_wif
-      return [nil, :missing] if wif.nil? || wif.empty?
+    def identity_missing
+      {
+        public_key: nil,
+        address: nil,
+        address_note: "No wallet configured — identity not available."
+      }
+    end
 
-      [::BSV::Primitives::PrivateKey.from_wif(wif), :ok]
-    rescue ArgumentError
-      [nil, :invalid]
+    def identity_invalid
+      {
+        public_key: nil,
+        address: nil,
+        address_note: "Wallet is configured but identity key could not be resolved — check wallet configuration."
+      }
     end
 
     def response_headers(content_type)

--- a/spec/x402/status_endpoint_spec.rb
+++ b/spec/x402/status_endpoint_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe X402::StatusEndpoint do
       end
     end
 
+    # Duck-type test — verifies the status endpoint works with any
+    # wallet implementing get_public_key, not RemoteWallet's internals.
     context "with RemoteWallet mock" do
       let(:remote_wallet_mock) do
         hex = test_pubkey_hex

--- a/spec/x402/status_endpoint_spec.rb
+++ b/spec/x402/status_endpoint_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe X402::StatusEndpoint do
       status, _headers, body = app.call(authed_env("/_x402/status"))
       expect(status).to eq(200)
       expect(body.first).to include("(not configured)")
-      expect(body.first).to include("server_wif is not configured")
+      expect(body.first).to include("No wallet configured")
     end
   end
 
@@ -262,7 +262,7 @@ RSpec.describe X402::StatusEndpoint do
       status, _headers, body = app.call(authed_env("/_x402/status"))
       expect(status).to eq(200)
       expect(body.first).to include("(not configured)")
-      expect(body.first).to include("server_wif is set but failed to parse")
+      expect(body.first).to include("identity key could not be resolved")
     end
   end
 

--- a/spec/x402/status_endpoint_spec.rb
+++ b/spec/x402/status_endpoint_spec.rb
@@ -21,11 +21,23 @@ RSpec.describe X402::StatusEndpoint do
     gw
   end
 
-  def configure_with(token: "secret-token", enabled: true, path: nil)
+  # Builds a mock wallet that returns the given public key hex from
+  # get_public_key. Accepts a positional hash (ProtoWallet style).
+  def mock_wallet_returning(pubkey_hex)
+    wallet = Object.new
+    wallet.define_singleton_method(:get_public_key) { |_args| { public_key: pubkey_hex } }
+    wallet
+  end
+
+  def configure_with(token: "secret-token", enabled: true, path: nil, wallet: nil)
     X402.reset_configuration!
     X402.configure do |c|
       c.domain = "api.example.com"
-      c.server_wif = test_wif
+      if wallet
+        c.wallet = wallet
+      else
+        c.server_wif = test_wif
+      end
       c.gateways = [mock_gateway]
       c.protect(method: "GET", path: "/premium", amount_sats: 50)
       c.status_endpoint_token = token if token
@@ -60,34 +72,195 @@ RSpec.describe X402::StatusEndpoint do
     end
   end
 
-  describe "rendering with valid bearer token" do
+  describe "wallet-based identity resolution" do
+    context "with server_wif (ProtoWallet path)" do
+      before { configure_with }
+
+      it "displays the correct public key and address" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        html = body.first
+        expect(html).to include(test_pubkey_hex)
+        expect(html).to include(test_address)
+        expect(html).to include("Identity address")
+        expect(html).to include("Not the per-payment receive address")
+      end
+
+      it "derives the address from the public key hex" do
+        expected_address = BSV::Primitives::PublicKey.from_hex(test_pubkey_hex).address
+        expect(expected_address).to eq(test_address)
+
+        status, _headers, body = app.call(authed_env("/_x402/status?format=json"))
+        expect(status).to eq(200)
+        data = JSON.parse(body.first)
+        expect(data["identity"]["address"]).to eq(expected_address)
+      end
+    end
+
+    context "with explicit wallet (WalletClient mock)" do
+      let(:wallet_mock) { mock_wallet_returning(test_pubkey_hex) }
+
+      before { configure_with(wallet: wallet_mock) }
+
+      it "displays the correct public key and address" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        html = body.first
+        expect(html).to include(test_pubkey_hex)
+        expect(html).to include(test_address)
+      end
+    end
+
+    context "with RemoteWallet mock" do
+      let(:remote_wallet_mock) do
+        hex = test_pubkey_hex
+        wallet = Object.new
+        wallet.define_singleton_method(:get_public_key) { |_args| { public_key: hex } }
+        wallet
+      end
+
+      before { configure_with(wallet: remote_wallet_mock) }
+
+      it "displays the correct public key and address" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        html = body.first
+        expect(html).to include(test_pubkey_hex)
+        expect(html).to include(test_address)
+      end
+    end
+
+    context "with no wallet configured (payee_locking_script_hex only)" do
+      before do
+        X402.reset_configuration!
+        X402.configure do |c|
+          c.domain = "api.example.com"
+          c.payee_locking_script_hex = "76a914#{"aa" * 20}88ac"
+          c.gateways = [mock_gateway]
+          c.protect(method: "GET", path: "/premium", amount_sats: 50)
+          c.status_endpoint_token = "secret-token"
+          c.enable_status_endpoint
+        end
+      end
+
+      it "renders gracefully with nil pubkey and address" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        expect(body.first).to include("(not configured)")
+        expect(body.first).to include("No wallet configured")
+      end
+
+      it "returns nil identity fields in JSON" do
+        status, _headers, body = app.call(authed_env("/_x402/status?format=json"))
+        expect(status).to eq(200)
+        data = JSON.parse(body.first)
+        expect(data["identity"]["public_key"]).to be_nil
+        expect(data["identity"]["address"]).to be_nil
+        expect(data["identity"]["address_note"]).to include("No wallet configured")
+      end
+    end
+
+    context "when wallet raises ConfigurationError" do
+      let(:failing_wallet) do
+        wallet = Object.new
+        wallet.define_singleton_method(:get_public_key) do |_args|
+          raise X402::ConfigurationError, "remote wallet unreachable"
+        end
+        wallet
+      end
+
+      before { configure_with(wallet: failing_wallet) }
+
+      it "degrades gracefully with an error note" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        expect(body.first).to include("(not configured)")
+        expect(body.first).to include("identity key could not be resolved")
+      end
+    end
+
+    context "when wallet raises unexpected StandardError" do
+      let(:erroring_wallet) do
+        wallet = Object.new
+        wallet.define_singleton_method(:get_public_key) do |_args|
+          raise StandardError, "something went wrong"
+        end
+        wallet
+      end
+
+      before { configure_with(wallet: erroring_wallet) }
+
+      it "degrades gracefully without crashing" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        expect(body.first).to include("(not configured)")
+        expect(body.first).to include("identity key could not be resolved")
+      end
+    end
+
+    context "when wallet returns malformed key" do
+      let(:bad_key_wallet) { mock_wallet_returning("not-valid-hex") }
+
+      before { configure_with(wallet: bad_key_wallet) }
+
+      it "degrades gracefully with an error note" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        expect(body.first).to include("(not configured)")
+        expect(body.first).to include("identity key could not be resolved")
+      end
+    end
+
+    context "with invalid server_wif" do
+      before do
+        X402.reset_configuration!
+        X402.configure do |c|
+          c.domain = "api.example.com"
+          c.server_wif = "not-a-real-wif"
+          c.payee_locking_script_hex = "76a914#{"aa" * 20}88ac"
+          c.gateways = [mock_gateway]
+          c.protect(method: "GET", path: "/premium", amount_sats: 50)
+          c.status_endpoint_token = "secret-token"
+          c.enable_status_endpoint
+        end
+      end
+
+      it "surfaces a wallet-agnostic error rather than silently swallowing" do
+        status, _headers, body = app.call(authed_env("/_x402/status"))
+        expect(status).to eq(200)
+        expect(body.first).to include("(not configured)")
+        expect(body.first).to include("identity key could not be resolved")
+      end
+    end
+
+    context "JSON format with wallet-backed identity" do
+      before { configure_with }
+
+      it "returns correct JSON structure with pubkey and address" do
+        status, headers, body = app.call(authed_env("/_x402/status?format=json"))
+        expect(status).to eq(200)
+        expect(headers["content-type"]).to eq("application/json")
+        expect(headers["cache-control"]).to eq("no-store")
+        expect(headers["vary"]).to eq("Accept, Authorization")
+        data = JSON.parse(body.first)
+        expect(data["x402_rack_version"]).to eq(X402::VERSION)
+        expect(data["identity"]["public_key"]).to eq(test_pubkey_hex)
+        expect(data["identity"]["address"]).to eq(test_address)
+        expect(data["identity"]["address_note"]).to include("Not the per-payment")
+      end
+    end
+  end
+
+  describe "rendering format" do
     before { configure_with }
 
-    it "renders HTML by default" do
+    it "renders HTML by default with correct headers" do
       status, headers, body = app.call(authed_env("/_x402/status"))
       expect(status).to eq(200)
       expect(headers["content-type"]).to start_with("text/html")
       expect(headers["cache-control"]).to eq("no-store")
       expect(headers["vary"]).to eq("Accept, Authorization")
-      html = body.first
-      expect(html).to include(test_pubkey_hex)
-      expect(html).to include(test_address)
-      expect(html).to include("Identity address")
-      expect(html).to include("Not the per-payment receive address")
-      expect(html).to include("x402-rack v#{X402::VERSION}")
-    end
-
-    it "renders JSON when ?format=json" do
-      status, headers, body = app.call(authed_env("/_x402/status?format=json"))
-      expect(status).to eq(200)
-      expect(headers["content-type"]).to eq("application/json")
-      expect(headers["cache-control"]).to eq("no-store")
-      expect(headers["vary"]).to eq("Accept, Authorization")
-      data = JSON.parse(body.first)
-      expect(data["x402_rack_version"]).to eq(X402::VERSION)
-      expect(data["identity"]["public_key"]).to eq(test_pubkey_hex)
-      expect(data["identity"]["address"]).to eq(test_address)
-      expect(data["identity"]["address_note"]).to include("Not the per-payment")
+      expect(body.first).to include("x402-rack v#{X402::VERSION}")
     end
 
     it "renders JSON when Accept: application/json" do
@@ -220,49 +393,6 @@ RSpec.describe X402::StatusEndpoint do
       status, _headers, body = app.call(env_for("/_x402/status"))
       expect(status).to eq(200)
       expect(body).to eq(["OK"])
-    end
-  end
-
-  describe "without server_wif" do
-    before do
-      X402.reset_configuration!
-      X402.configure do |c|
-        c.domain = "api.example.com"
-        c.payee_locking_script_hex = "76a914#{"aa" * 20}88ac"
-        c.gateways = [mock_gateway]
-        c.protect(method: "GET", path: "/premium", amount_sats: 50)
-        c.status_endpoint_token = "secret-token"
-        c.enable_status_endpoint
-      end
-    end
-
-    it "renders gracefully with placeholders" do
-      status, _headers, body = app.call(authed_env("/_x402/status"))
-      expect(status).to eq(200)
-      expect(body.first).to include("(not configured)")
-      expect(body.first).to include("No wallet configured")
-    end
-  end
-
-  describe "with invalid server_wif" do
-    before do
-      X402.reset_configuration!
-      X402.configure do |c|
-        c.domain = "api.example.com"
-        c.server_wif = "not-a-real-wif"
-        c.payee_locking_script_hex = "76a914#{"aa" * 20}88ac"
-        c.gateways = [mock_gateway]
-        c.protect(method: "GET", path: "/premium", amount_sats: 50)
-        c.status_endpoint_token = "secret-token"
-        c.enable_status_endpoint
-      end
-    end
-
-    it "surfaces a distinct invalid-WIF message rather than silently swallowing" do
-      status, _headers, body = app.call(authed_env("/_x402/status"))
-      expect(status).to eq(200)
-      expect(body.first).to include("(not configured)")
-      expect(body.first).to include("identity key could not be resolved")
     end
   end
 


### PR DESCRIPTION
## Summary

- Replaces the private `identity_private_key` method in `StatusEndpoint` with wallet-based identity resolution via `config.shared_wallet.get_public_key(identity_key: true)`, matching the pattern already used in `BRC121Gateway`
- Removes all direct references to `server_wif`, `PrivateKey`, and `from_wif` from `status_endpoint.rb`
- Error messages are now wallet-agnostic — works correctly whether the wallet is a `ProtoWallet` (from `server_wif`), `WalletClient`, or `RemoteWallet`
- All wallet failures degrade gracefully (nil pubkey/address + descriptive note) — the endpoint never crashes

## Test plan

- [x] ProtoWallet path (via `server_wif`) displays correct pubkey + address
- [x] Explicit `WalletClient` mock displays correct pubkey + address
- [x] `RemoteWallet` mock displays correct pubkey + address
- [x] No wallet configured (payee_locking_script_hex only) degrades gracefully
- [x] Wallet raises `ConfigurationError` — degrades with error note
- [x] Wallet raises unexpected `StandardError` — degrades without crashing
- [x] Wallet returns malformed key hex — degrades with error note
- [x] JSON format returns correct structure with wallet-backed identity
- [x] Full suite: 413 examples, 0 failures, RuboCop clean

Closes #143
