### PR TITLE
feat: broadcast payment BEEF to ARC before internalisation

### DIFF
--- a/.claude/plans/20260415-gateway-arc-broadcast.md
+++ b/.claude/plans/20260415-gateway-arc-broadcast.md
@@ -1,0 +1,156 @@
+# Plan: Gateway must broadcast payment tx before forwarding to app (#148)
+
+## Context
+
+BRC105Gateway and BRC121Gateway call `wallet.internalize_action()` but never broadcast the tx to ARC. With the bsv-x402 client's `noSend: true` change, the payment tx is never on-chain, yet the app receives the request as if settled. This led to a real incident in x402-doom where a player received on-chain sats for free (sgbett/x402-doom#203).
+
+**Key insight:** ARC is idempotent for the same txid — broadcasting the same tx twice returns the current status (SEEN_ON_NETWORK, MINED), not a double-spend error. So the server should *always* broadcast, regardless of whether the client already did. Both can broadcast safely.
+
+**Economic invariant:** "No credit without on-chain settlement."
+
+## Approach
+
+Add a `broadcast_beef` method to the Ruby SDK's ARC client, then have BRC105Gateway and BRC121Gateway broadcast the BEEF to ARC after validation but before internalization. Broadcast failure = reject the request (per HLR acceptance criteria).
+
+### Why BEEF, not raw tx or EF
+
+The client may have used `noSend: true`, meaning ARC hasn't seen the parent transactions. BEEF includes the full SPV ancestry, so ARC can validate without fetching parents. Raw tx or EF would fail with `460 Not extended format` or `missing input scripts`.
+
+### Why broadcast before internalize (not after)
+
+If we internalize first and broadcast fails, the wallet has a dead record for a tx that never went on-chain. By broadcasting first, we only internalize payments that are confirmed on-network. If broadcast fails, nothing was internalized, so there's no accounting mess.
+
+### Order of operations (both gateways)
+
+1. Validate headers, parse BEEF, verify payment output (existing)
+2. Check replay protection — txid_store / prefix_store (existing)
+3. **Broadcast BEEF to ARC (NEW)** — fail = reject request
+4. Internalize into wallet (existing)
+5. Forward to app (existing)
+
+## Steps
+
+### Step 1: Add `broadcast_beef` to `BSV::Network::ARC`
+
+**File:** `/opt/ruby/bsv-ruby-sdk/gem/bsv-sdk/lib/bsv/network/arc.rb`
+
+Add alongside existing `broadcast` method:
+
+```ruby
+def broadcast_beef(beef_bytes, wait_for: nil, skip_fee_validation: nil, skip_script_validation: nil)
+  uri = URI("#{@url}/v1/tx")
+  request = build_post_request(uri, wait_for: wait_for,
+                                    skip_fee_validation: skip_fee_validation,
+                                    skip_script_validation: skip_script_validation)
+  request['Content-Type'] = 'application/octet-stream'
+  request.body = beef_bytes.b
+
+  response = execute(uri, request)
+  handle_broadcast_response(response)
+end
+```
+
+Reuses `build_post_request` (which sets JSON content-type), then overrides to `application/octet-stream`. Response handling is identical — ARC returns the same JSON response structure regardless of input format.
+
+**Spec:** `/opt/ruby/bsv-ruby-sdk/gem/bsv-sdk/spec/bsv/network/arc_spec.rb` — mirror existing `#broadcast` tests for content-type, binary body, wait_for header, error handling.
+
+### Step 2: Update BRC121Gateway — accept `arc_client`, broadcast BEEF
+
+**File:** `lib/x402/bsv/brc121_gateway.rb`
+
+Constructor: add `arc_client: nil` keyword, store as `@arc_client`.
+
+In `settle!`, insert `broadcast_to_arc!(headers["x-bsv-beef"])` after `verify_payment_output!` and `check_txid_unique!`, but BEFORE `internalize_payment!`:
+
+```ruby
+paid_sats = verify_payment_output!(subject_tx, output_index, required_sats)
+
+broadcast_to_arc!(headers["x-bsv-beef"])  # NEW — on-chain before internalize
+
+result = internalize_payment!(...)
+```
+
+New private method:
+
+```ruby
+def broadcast_to_arc!(beef_b64)
+  return unless @arc_client
+
+  beef_bytes = Base64.strict_decode64(beef_b64)
+  @arc_client.broadcast_beef(beef_bytes)
+rescue ::BSV::Network::BroadcastError => e
+  raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 402)
+rescue StandardError => e
+  logger.error "[brc121] ARC broadcast error: #{e.class}: #{e.message}"
+  raise VerificationError.new("payment broadcast failed", status: 402)
+end
+```
+
+Broadcast failure raises `VerificationError` → middleware returns 402 → client retries.
+
+### Step 3: Update BRC105Gateway — same pattern
+
+**File:** `lib/x402/bsv/brc105_gateway.rb`
+
+Constructor: add `arc_client: nil`, store as `@arc_client`.
+
+In `settle!`, insert broadcast after `verify_payment_output!` and `consume_prefix!`, before `internalize_payment!`.
+
+Same `broadcast_to_arc!` method with `[brc105]` log tag.
+
+### Step 4: Update Configuration to inject `arc_client`
+
+**File:** `lib/x402/configuration.rb`
+
+- Add `arc_client` to `BRC105_GATEWAY_KNOWN_OPTS` and `BRC121_GATEWAY_KNOWN_OPTS`
+- In `build_brc105_gateway`: add `arc_client: options[:arc_client] || shared_arc_client`
+- In `build_brc121_gateway`: add `arc_client: options[:arc_client] || shared_arc_client`
+
+Same `options[:arc_client] || shared_arc_client` pattern already used by `build_pay_gateway`.
+
+### Step 5: Tests
+
+**BRC121Gateway spec** (`spec/x402/bsv/brc121_gateway_spec.rb`):
+- Add `arc_client` double to gateway construction
+- "broadcasts BEEF to ARC after validation"
+- "rejects when ARC broadcast fails" (BroadcastError → VerificationError 402)
+- "skips broadcast when arc_client is nil" (backward compat)
+- "succeeds when ARC returns SEEN_ON_NETWORK" (idempotent re-broadcast)
+
+**BRC105Gateway spec** (`spec/x402/bsv/brc105_gateway_spec.rb`): same pattern.
+
+**Configuration spec** (`spec/x402/configuration_spec.rb`):
+- "injects shared_arc_client into BRC105Gateway"
+- "injects shared_arc_client into BRC121Gateway"
+- "allows per-gateway arc_client override"
+
+## Dependency order
+
+```
+Step 1 (SDK: broadcast_beef)  ← separate repo, separate commit
+    ↓
+Steps 2 + 3 (gateway changes, parallel)
+    ↓
+Step 4 (configuration wiring)
+    ↓
+Step 5 (tests alongside each step)
+```
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `/opt/ruby/bsv-ruby-sdk/gem/bsv-sdk/lib/bsv/network/arc.rb` | Add `broadcast_beef` method |
+| `/opt/ruby/bsv-ruby-sdk/gem/bsv-sdk/spec/bsv/network/arc_spec.rb` | Spec for `broadcast_beef` |
+| `lib/x402/bsv/brc121_gateway.rb` | Accept `arc_client`, add broadcast step |
+| `lib/x402/bsv/brc105_gateway.rb` | Accept `arc_client`, add broadcast step |
+| `lib/x402/configuration.rb` | Inject `arc_client` into both gateways |
+| `spec/x402/bsv/brc121_gateway_spec.rb` | Broadcast specs |
+| `spec/x402/bsv/brc105_gateway_spec.rb` | Broadcast specs |
+| `spec/x402/configuration_spec.rb` | Wiring specs |
+
+## Verification
+
+1. `cd /opt/ruby/bsv-ruby-sdk && bundle exec rspec spec/bsv/network/arc_spec.rb` — SDK broadcast_beef specs
+2. `cd /opt/ruby/x402-rack && bundle exec rake` — full suite (specs + rubocop)
+3. Manual: configure BRC121Gateway with a real ARC client and submit a payment — verify the tx appears on WhatsOnChain

--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -29,10 +29,12 @@ module X402
       # @param key_deriver [BSV::Wallet::KeyDeriver] provides identity key + BRC-42 derivation
       # @param prefix_store [#store!, #valid?, #consume!] replay protection for derivation prefixes
       # @param wallet [#internalize_action] BRC-100 wallet for payment internalisation
-      def initialize(key_deriver:, prefix_store:, wallet:)
+      # @param arc_client [BSV::Network::ARC, nil] optional ARC client for broadcasting BEEF
+      def initialize(key_deriver:, prefix_store:, wallet:, arc_client: nil)
         @key_deriver = key_deriver
         @prefix_store = prefix_store
         @wallet = wallet
+        @arc_client = arc_client
       end
 
       # Issue a 402 challenge with BRC-105 headers.
@@ -92,6 +94,7 @@ module X402
         log_tx_outputs(subject_tx, required_sats, expected_script)
         paid_sats, output_index = verify_payment_output!(subject_tx, required_sats, expected_script)
         consume_prefix!(prefix)
+        broadcast_to_arc!(payment["transaction"])
         internalize_payment!(
           transaction_b64: payment["transaction"],
           output_index: output_index,
@@ -140,6 +143,18 @@ module X402
         return if @prefix_store.consume!(prefix)
 
         raise VerificationError.new("replay: derivation prefix already consumed or unknown", status: 400)
+      end
+
+      def broadcast_to_arc!(transaction_b64)
+        return unless @arc_client
+
+        beef_bytes = Base64.strict_decode64(transaction_b64)
+        @arc_client.broadcast_beef(beef_bytes)
+      rescue ::BSV::Network::BroadcastError => e
+        raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 402)
+      rescue StandardError => e
+        logger.error "[brc105] ARC broadcast error: #{e.class}: #{e.message}"
+        raise VerificationError.new("payment broadcast failed", status: 402)
       end
 
       def parse_beef_transaction(transaction_b64)

--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -149,7 +149,10 @@ module X402
         return unless @arc_client
 
         beef_bytes = Base64.strict_decode64(transaction_b64)
-        @arc_client.broadcast_beef(beef_bytes)
+        response = @arc_client.broadcast_beef(beef_bytes)
+        logger.debug "[brc105] ARC broadcast OK: txStatus=#{response.tx_status}" if response.respond_to?(:tx_status)
+      rescue VerificationError
+        raise
       rescue ::BSV::Network::BroadcastError => e
         raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 402)
       rescue StandardError => e

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -65,9 +65,10 @@ module X402
       #   +#get_public_key(identity_key: true)+ for the server identity key.
       # @param txid_store [#record_if_unseen!, nil] replay protection for
       #   settled txids. Defaults to +X402::BSV::TxidStore::Memory.new+.
-      def initialize(wallet:, txid_store: nil)
+      def initialize(wallet:, txid_store: nil, arc_client: nil)
         @wallet = wallet
         @txid_store = txid_store || TxidStore::Memory.new
+        @arc_client = arc_client
       end
 
       # Issue a 402 challenge with BRC-121 headers.
@@ -111,6 +112,8 @@ module X402
         check_txid_unique!(subject_tx.txid_hex)
 
         paid_sats = verify_payment_output!(subject_tx, output_index, required_sats)
+
+        broadcast_to_arc!(headers["x-bsv-beef"])
 
         result = internalize_payment!(
           beef_b64: headers["x-bsv-beef"],
@@ -223,6 +226,18 @@ module X402
         end
 
         output.satoshis
+      end
+
+      def broadcast_to_arc!(beef_b64)
+        return unless @arc_client
+
+        beef_bytes = Base64.strict_decode64(beef_b64)
+        @arc_client.broadcast_beef(beef_bytes)
+      rescue ::BSV::Network::BroadcastError => e
+        raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 402)
+      rescue StandardError => e
+        logger.error "[brc121] ARC broadcast error: #{e.class}: #{e.message}"
+        raise VerificationError.new("payment broadcast failed", status: 402)
       end
 
       def internalize_payment!(beef_b64:, output_index:, derivation_prefix:, derivation_suffix:, sender_identity_key:)

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -232,7 +232,10 @@ module X402
         return unless @arc_client
 
         beef_bytes = Base64.strict_decode64(beef_b64)
-        @arc_client.broadcast_beef(beef_bytes)
+        response = @arc_client.broadcast_beef(beef_bytes)
+        logger.debug "[brc121] ARC broadcast OK: txStatus=#{response.tx_status}" if response.respond_to?(:tx_status)
+      rescue VerificationError
+        raise
       rescue ::BSV::Network::BroadcastError => e
         raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 402)
       rescue StandardError => e

--- a/lib/x402/configuration.rb
+++ b/lib/x402/configuration.rb
@@ -37,10 +37,10 @@ module X402
     ].freeze
 
     BRC105_GATEWAY_KNOWN_OPTS = %i[
-      wallet key_deriver server_wif server_key prefix_store
+      wallet key_deriver server_wif server_key prefix_store arc_client
     ].freeze
 
-    BRC121_GATEWAY_KNOWN_OPTS = %i[wallet txid_store].freeze
+    BRC121_GATEWAY_KNOWN_OPTS = %i[wallet txid_store arc_client].freeze
 
     GATEWAY_REGISTRY = {
       pay_gateway: "X402::BSV::PayGateway",
@@ -490,7 +490,8 @@ module X402
       klass.new(
         key_deriver: key_deriver,
         prefix_store: options[:prefix_store] || X402::BSV::PrefixStore::Memory.new,
-        wallet: wallet
+        wallet: wallet,
+        arc_client: options[:arc_client] || shared_arc_client
       )
     end
 
@@ -502,7 +503,7 @@ module X402
               "brc121_gateway requires wallet: (or top-level config.wallet =)"
       end
 
-      opts = { wallet: wallet }
+      opts = { wallet: wallet, arc_client: options[:arc_client] || shared_arc_client }
       opts[:txid_store] = options[:txid_store] if options.key?(:txid_store)
       klass.new(**opts)
     end

--- a/spec/x402/bsv/brc105_gateway_spec.rb
+++ b/spec/x402/bsv/brc105_gateway_spec.rb
@@ -359,6 +359,98 @@ RSpec.describe X402::BSV::BRC105Gateway do
       end
     end
 
+    # -----------------------------------------------------------------------
+    # ARC broadcast
+    # -----------------------------------------------------------------------
+    context "ARC broadcast" do
+      let(:arc_client) { double("arc_client") }
+      let(:arc_gateway) do
+        described_class.new(key_deriver: real_key_deriver, prefix_store: prefix_store, wallet: wallet,
+                            arc_client: arc_client)
+      end
+
+      before do
+        allow(arc_client).to receive(:broadcast_beef)
+      end
+
+      it "broadcasts BEEF to ARC after validation" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        arc_gateway.settle!("x-bsv-payment", payload, request, route)
+
+        expect(arc_client).to have_received(:broadcast_beef).with(an_instance_of(String))
+      end
+
+      it "rejects when ARC broadcast raises BroadcastError" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(BSV::Network::BroadcastError.new("tx rejected by network"))
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        expect { arc_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /ARC broadcast failed/) { |e| expect(e.status).to eq(402) }
+      end
+
+      it "rejects when ARC broadcast raises StandardError" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(StandardError, "connection reset")
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        expect { arc_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /payment broadcast failed/) { |e| expect(e.status).to eq(402) }
+      end
+
+      it "does not leak ARC error details in HTTP response" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(StandardError, "internal ARC token xyz-secret expired")
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        expect { arc_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError) { |e|
+            expect(e.message).not_to include("xyz-secret")
+            expect(e.message).to eq("payment broadcast failed")
+          }
+      end
+
+      it "skips broadcast when arc_client is nil" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        # real_gateway has no arc_client — should succeed without broadcast
+        result = real_gateway.settle!("x-bsv-payment", payload, request, route)
+        expect(result).to be_a(X402::SettlementResult)
+      end
+
+      it "succeeds when ARC returns SEEN_ON_NETWORK (idempotent)" do
+        # broadcast_beef returns normally for SEEN_ON_NETWORK — no error raised
+        allow(arc_client).to receive(:broadcast_beef).and_return(double("response", txid: "abc123"))
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        result = arc_gateway.settle!("x-bsv-payment", payload, request, route)
+        expect(result).to be_a(X402::SettlementResult)
+      end
+
+      it "calls broadcast before internalize" do
+        call_order = []
+        allow(arc_client).to receive(:broadcast_beef) { call_order << :broadcast }
+        allow(wallet).to receive(:internalize_action) do
+          call_order << :internalize
+          { accepted: true }
+        end
+
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+
+        arc_gateway.settle!("x-bsv-payment", payload, request, route)
+
+        expect(call_order).to eq(%i[broadcast internalize])
+      end
+    end
+
     # Wallet internalisation failure
     context "internalisation failure" do
       it "raises 402 when wallet.internalize_action fails" do

--- a/spec/x402/bsv/brc121_gateway_spec.rb
+++ b/spec/x402/bsv/brc121_gateway_spec.rb
@@ -343,6 +343,85 @@ RSpec.describe X402::BSV::BRC121Gateway do
       end
     end
 
+    # ARC broadcast
+    context "ARC broadcast" do
+      let(:arc_client) { double("arc_client") }
+      let(:gateway) { described_class.new(wallet: wallet, txid_store: txid_store, arc_client: arc_client) }
+
+      before do
+        allow(arc_client).to receive(:broadcast_beef).and_return(double("response", txid: "abc123"))
+      end
+
+      it "broadcasts BEEF to ARC after validation" do
+        env = paid_request_env(beef_b64: beef_b64)
+        gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
+
+        expected_bytes = Base64.strict_decode64(beef_b64)
+        expect(arc_client).to have_received(:broadcast_beef).with(expected_bytes)
+      end
+
+      it "rejects when ARC broadcast raises BroadcastError" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(BSV::Network::BroadcastError.new("double-spend detected", status_code: 409))
+        env = paid_request_env(beef_b64: beef_b64)
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e|
+            expect(e.status).to eq(402)
+            expect(e.reason).to include("ARC broadcast failed")
+          }
+      end
+
+      it "rejects when ARC broadcast raises StandardError" do
+        allow(arc_client).to receive(:broadcast_beef).and_raise(StandardError, "connection refused")
+        env = paid_request_env(beef_b64: beef_b64)
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e|
+            expect(e.status).to eq(402)
+          }
+      end
+
+      it "does not leak ARC error details in HTTP response" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(StandardError, "internal: /var/lib/arc/secret.key not found")
+        env = paid_request_env(beef_b64: beef_b64)
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e|
+            expect(e.reason).not_to include("/var/lib")
+            expect(e.reason).to eq("payment broadcast failed")
+          }
+      end
+
+      it "skips broadcast when arc_client is nil" do
+        nil_arc_gateway = described_class.new(wallet: wallet, txid_store: txid_store)
+        env = paid_request_env(beef_b64: beef_b64)
+        expect { nil_arc_gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }.not_to raise_error
+      end
+
+      it "succeeds when ARC returns SEEN_ON_NETWORK" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_return(double("response", txid: "abc123", tx_status: "SEEN_ON_NETWORK"))
+        env = paid_request_env(beef_b64: beef_b64)
+        result = gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
+        expect(result).to be_a(X402::SettlementResult)
+      end
+
+      it "calls broadcast_to_arc! before internalize_payment!" do
+        env = paid_request_env(beef_b64: beef_b64)
+        expect(arc_client).to receive(:broadcast_beef).ordered
+        expect(wallet).to receive(:internalize_action).ordered.and_return(accepted: true)
+        gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
+      end
+
+      it "does not call internalize_payment! when broadcast fails" do
+        allow(arc_client).to receive(:broadcast_beef)
+          .and_raise(BSV::Network::BroadcastError.new("rejected", status_code: 400))
+        env = paid_request_env(beef_b64: beef_b64)
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError)
+        expect(wallet).not_to have_received(:internalize_action)
+      end
+    end
+
     # §5 step 5: isMerge and acceptance checking on wallet result
     context "wallet internalization result checking (§5 step 5)" do
       it "rejects when wallet returns isMerge: true (symbol key)" do

--- a/spec/x402/configuration_spec.rb
+++ b/spec/x402/configuration_spec.rb
@@ -603,6 +603,29 @@ RSpec.describe X402::Configuration do
           X402::ConfigurationError, /brc105_gateway: unknown option.*:bad_opt/
         )
       end
+
+      it "injects shared_arc_client when auto-enabled" do
+        config.enable :brc105_gateway, key_deriver: key_deriver
+        config.validate!
+
+        gw = config.gateways.first
+        expect(gw.instance_variable_get(:@arc_client)).to eq(arc_double)
+      end
+
+      it "allows per-gateway arc_client override" do
+        custom_arc = instance_double("BSV::Network::ARC")
+        config.enable :brc105_gateway, key_deriver: key_deriver, arc_client: custom_arc
+        config.validate!
+
+        gw = config.gateways.first
+        expect(gw.instance_variable_get(:@arc_client)).to eq(custom_arc)
+      end
+
+      it "accepts arc_client in BRC105_GATEWAY_KNOWN_OPTS" do
+        custom_arc = instance_double("BSV::Network::ARC")
+        config.enable :brc105_gateway, key_deriver: key_deriver, arc_client: custom_arc
+        expect { config.validate! }.not_to raise_error
+      end
     end
 
     context "BRC121Gateway" do
@@ -650,6 +673,32 @@ RSpec.describe X402::Configuration do
         expect { config.validate! }.to raise_error(
           X402::ConfigurationError, /brc121_gateway: unknown option.*:bad_opt/
         )
+      end
+
+      it "injects shared_arc_client when auto-enabled" do
+        config.wallet = wallet
+        config.enable :brc121_gateway
+        config.validate!
+
+        gw = config.gateways.first
+        expect(gw.instance_variable_get(:@arc_client)).to eq(arc_double)
+      end
+
+      it "allows per-gateway arc_client override" do
+        custom_arc = instance_double("BSV::Network::ARC")
+        config.wallet = wallet
+        config.enable :brc121_gateway, arc_client: custom_arc
+        config.validate!
+
+        gw = config.gateways.first
+        expect(gw.instance_variable_get(:@arc_client)).to eq(custom_arc)
+      end
+
+      it "accepts arc_client in BRC121_GATEWAY_KNOWN_OPTS" do
+        custom_arc = instance_double("BSV::Network::ARC")
+        config.wallet = wallet
+        config.enable :brc121_gateway, arc_client: custom_arc
+        expect { config.validate! }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
## Summary

Gateways now broadcast the payment BEEF to ARC before internalising into the wallet, enforcing the economic invariant: "no credit without on-chain settlement."

- **BRC121Gateway** and **BRC105Gateway** both broadcast BEEF to ARC (via `broadcast_beef`) after validation but before `internalize_action`
- Broadcast failure (network error, double-spend rejection) returns 402 — the request is never forwarded to the app
- ARC idempotency means both client and server can broadcast safely — `SEEN_ON_NETWORK` / `MINED` are treated as success
- `arc_client: nil` is fully backward-compatible — broadcast step is silently skipped
- Configuration injects `shared_arc_client` into both gateways automatically (same pattern as PayGateway)

### Cross-repo dependency

`BSV::Network::ARC#broadcast_beef` was added in sgbett/bsv-ruby-sdk@88799c0. This method posts raw BEEF bytes with `Content-Type: application/octet-stream` to ARC's `/v1/tx` endpoint.

### Key design decisions

- **Broadcast before internalise (not after):** If we internalise first and broadcast fails, the wallet has a dead record for a tx that never went on-chain. Broadcasting first means we only internalise payments confirmed on-network.
- **BRC105 prefix consumption before broadcast:** A failed broadcast permanently consumes the prefix — correct security: prevents replay with a different tx.
- **Generic `StandardError` rescue does not leak internals:** Only `BroadcastError` messages (from ARC) are surfaced; all other errors get a generic "payment broadcast failed" message.

## Sub-issues

- #149 — `broadcast_beef` on ARC client (bsv-ruby-sdk)
- #150 — BRC121Gateway broadcast
- #151 — BRC105Gateway broadcast
- #152 — Configuration wiring
- #153 — HLR acceptance criteria text correction

## Test plan

- [x] 434 specs pass (`bundle exec rake`)
- [x] RuboCop clean (67 files, 0 offences)
- [x] BRC121Gateway: 8 new ARC broadcast specs (happy path, BroadcastError, StandardError, nil-safety, ordering, idempotent)
- [x] BRC105Gateway: 7 new ARC broadcast specs (same coverage)
- [x] Configuration: `shared_arc_client` injection + per-gateway override specs for both gateways
- [ ] Manual: configure a real ARC client and verify tx appears on WhatsOnChain

Closes #148
