### PR TITLE
fix: use find_atomic_transaction to wire BEEF ancestry before broadcast (#177)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     x402-rack (0.11.0)
       base64 (~> 0.2)
       bsv-sdk (>= 0.12.1, < 1.0)
-      bsv-wallet (>= 0.5.0, < 1.0)
+      bsv-wallet (>= 0.9.1, < 1.0)
       json-canonicalization (~> 1.0)
       rack (~> 3.0)
 
@@ -18,9 +18,9 @@ GEM
     bigdecimal (4.1.1)
     bsv-sdk (0.12.1)
       mcp (~> 0.12)
-    bsv-wallet (0.9.0)
+    bsv-wallet (0.9.1)
       base64 (~> 0.2)
-      bsv-sdk (>= 0.11.0, < 1.0)
+      bsv-sdk (>= 0.12.1, < 1.0)
     capybara (3.40.0)
       addressable
       matrix

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     x402-rack (0.11.0)
       base64 (~> 0.2)
-      bsv-sdk (>= 0.12.0, < 1.0)
+      bsv-sdk (>= 0.12.1, < 1.0)
       bsv-wallet (>= 0.5.0, < 1.0)
       json-canonicalization (~> 1.0)
       rack (~> 3.0)
@@ -16,7 +16,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.1)
-    bsv-sdk (0.12.0)
+    bsv-sdk (0.12.1)
       mcp (~> 0.12)
     bsv-wallet (0.9.0)
       base64 (~> 0.2)

--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -198,7 +198,11 @@ module X402
 
         raw = Base64.strict_decode64(transaction_b64)
         beef = ::BSV::Transaction::Beef.from_binary(raw)
-        subject_tx = beef.find_transaction(beef.subject_txid)
+        # find_atomic_transaction wires ancestry (source_transaction on each
+        # input). Required so arc.broadcast(subject_tx) can emit EF —
+        # otherwise we fall back to raw hex and ARC rejects broadcasts whose
+        # parents are unconfirmed and only present in the BEEF. See #177.
+        subject_tx = beef.find_atomic_transaction(beef.subject_txid)
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless subject_tx
 
         subject_tx

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -217,7 +217,11 @@ module X402
       def parse_beef_transaction(transaction_b64)
         raw = Base64.strict_decode64(transaction_b64)
         beef = ::BSV::Transaction::Beef.from_binary(raw)
-        subject_tx = beef.find_transaction(beef.subject_txid)
+        # find_atomic_transaction wires ancestry (source_transaction on each
+        # input). Required so arc.broadcast(subject_tx) can emit EF —
+        # otherwise we fall back to raw hex and ARC rejects broadcasts whose
+        # parents are unconfirmed and only present in the BEEF. See #177.
+        subject_tx = beef.find_atomic_transaction(beef.subject_txid)
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless subject_tx
 
         subject_tx

--- a/x402-rack.gemspec
+++ b/x402-rack.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "base64", "~> 0.2"
-  spec.add_dependency "bsv-sdk", ">= 0.12.0", "< 1.0"
+  spec.add_dependency "bsv-sdk", ">= 0.12.1", "< 1.0"
   spec.add_dependency "bsv-wallet", ">= 0.5.0", "< 1.0"
   spec.add_dependency "json-canonicalization", "~> 1.0"
   spec.add_dependency "rack", "~> 3.0"

--- a/x402-rack.gemspec
+++ b/x402-rack.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64", "~> 0.2"
   spec.add_dependency "bsv-sdk", ">= 0.12.1", "< 1.0"
-  spec.add_dependency "bsv-wallet", ">= 0.5.0", "< 1.0"
+  spec.add_dependency "bsv-wallet", ">= 0.9.1", "< 1.0"
   spec.add_dependency "json-canonicalization", "~> 1.0"
   spec.add_dependency "rack", "~> 3.0"
 end


### PR DESCRIPTION
## Summary

Fixes the ARC rejection pattern we've been seeing in the doom demo: when a client sends a BEEF containing unconfirmed parent transactions (normal for wallets spending recently-received UTXOs), our gateway was extracting the subject tx via \`Beef#find_transaction\` — which doesn't wire ancestry — and passing it to \`arc.broadcast(tx)\`. \`tx.to_ef_hex\` raised, the SDK fell back to raw hex, and ARC rejected because it couldn't resolve the parent txids against its view of the chain.

Swap to \`Beef#find_atomic_transaction\`, which internally calls \`wire_ancestry(tx)\` to attach \`source_transaction\` on every input. Combined with bsv-sdk 0.12.1's fix that makes \`Transaction#to_ef\` read through \`input.source_transaction\` to derive \`source_satoshis\` and \`source_locking_script\`, this closes the loop — \`arc.broadcast\` now emits valid EF and ARC accepts the tx regardless of whether parents are confirmed.

## Changes

- \`lib/x402/bsv/brc121_gateway.rb\` — one-line swap + explanatory comment
- \`lib/x402/bsv/brc105_gateway.rb\` — same
- \`x402-rack.gemspec\` — \`bsv-sdk\` floor raised to \`>= 0.12.1\` (the \`to_ef\` fix)
- \`Gemfile.lock\` — refreshed

## Test plan

- [x] \`bundle exec rake\` — 441 examples, 0 failures; RuboCop clean
- [x] e2e skipped cleanly (CLIENT_WIF UTXOs depleted from prior runs — will verify against testnet once refunded)
- [ ] Post-merge: verify against bsv-x402 / doom demo that ARC now accepts

## Related

- Issue [#177](https://github.com/sgbett/x402-rack/issues/177) — the fix tracker
- [bsv-ruby-sdk v0.12.1 release](https://github.com/sgbett/bsv-ruby-sdk/releases/tag/v0.12.1) — provides the SDK-side enablement
- [sgbett/bsv-ruby-sdk#466](https://github.com/sgbett/bsv-ruby-sdk/issues/466) — the producer-side ancestry HLR (orthogonal; affects \`create_action\` output rather than our consumer path)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)