### PR TITLE
fix: PayGateway broadcasts BEEF-extracted tx, not raw tx

### DIFF
--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -229,7 +229,8 @@ module X402
         beef = ::BSV::Transaction::Beef.from_binary(raw)
         txid = beef.subject_txid || beef.transactions.reverse_each.find(&:transaction)&.txid
         beef.find_atomic_transaction(txid)
-      rescue StandardError
+      rescue StandardError => e
+        logger.debug "[pay-gateway] BEEF extraction failed, falling back to raw tx: #{e.class}: #{e.message}"
         nil
       end
 

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -80,7 +80,7 @@ module X402
         check_txid_unique!(transaction)
         verify_payment_output!(transaction, required_sats, accepted_payee)
         verify_binding!(transaction, rack_request)
-        settle_transaction!(transaction, route)
+        settle_transaction!(transaction, route, beef_b64)
         relay_to_wallet(transaction, prefix, suffix, beef_b64)
         build_settlement_result(transaction)
       end
@@ -192,17 +192,23 @@ module X402
 
       # Determine the effective wait_for strategy and either broadcast
       # synchronously or enqueue for async settlement.
-      def settle_transaction!(transaction, route)
+      #
+      # When +beef_b64+ is present, extracts the subject transaction from
+      # the BEEF bundle (with ancestry wired via +find_atomic_transaction+)
+      # so ARC can validate inputs for +noSend+ payments. Falls back to
+      # the raw parsed transaction when no BEEF is available.
+      def settle_transaction!(transaction, route, beef_b64 = nil)
         effective = (route.arc_wait_for || arc_wait_for).to_s
+        broadcast_tx = (beef_b64 && extract_broadcast_tx(beef_b64)) || transaction
 
         if effective == "async"
           unless settlement_worker
             raise ConfigurationError,
                   "route arc_wait_for is :async but no settlement_worker configured"
           end
-          settlement_worker.enqueue(transaction.to_binary)
+          settlement_worker.enqueue(broadcast_tx.to_binary)
         else
-          broadcast!(transaction, wait_for: effective)
+          broadcast!(broadcast_tx, wait_for: effective)
         end
       end
 
@@ -212,6 +218,19 @@ module X402
         raise
       rescue StandardError
         raise VerificationError.new("ARC broadcast failed", status: 502)
+      end
+
+      # Parse the BEEF bundle and extract the subject transaction with
+      # source transaction ancestry wired on each input. This ensures
+      # ARC can validate inputs even for noSend payments where the
+      # parent UTXOs aren't yet known to the network.
+      def extract_broadcast_tx(beef_b64)
+        raw = Base64.strict_decode64(beef_b64)
+        beef = ::BSV::Transaction::Beef.from_binary(raw)
+        txid = beef.subject_txid || beef.transactions.reverse_each.find(&:transaction)&.txid
+        beef.find_atomic_transaction(txid)
+      rescue StandardError
+        nil
       end
 
       # Relay the settled transaction to the operator's wallet for tracking.

--- a/spec/x402/bsv/pay_gateway_spec.rb
+++ b/spec/x402/bsv/pay_gateway_spec.rb
@@ -422,6 +422,72 @@ RSpec.describe X402::BSV::PayGateway do
         Base64.strict_encode64(JSON.generate(payload))
       end
 
+      it "broadcasts BEEF-extracted tx (with ancestry) when beef is present in payload" do
+        broadcast_tx = nil
+        mock_arc_spy = Object.new
+        mock_arc_spy.define_singleton_method(:broadcast) do |tx, **|
+          broadcast_tx = tx
+          Struct.new(:txid, :tx_status).new("cc" * 32, "SEEN_ON_NETWORK")
+        end
+
+        spy_gateway = described_class.new(
+          arc_client: mock_arc_spy,
+          wallet: mock_wallet,
+          binding_mode: :permissive
+        )
+
+        proof = wallet_proof(spy_gateway)
+        spy_gateway.settle!("Payment-Signature", proof, mock_request, route)
+
+        expect(broadcast_tx).not_to be_nil
+        # BEEF-extracted tx should have source transactions wired on inputs
+        expect(broadcast_tx).to be_a(BSV::Transaction::Transaction)
+      end
+
+      it "falls back to raw tx when beef is absent from payload" do
+        broadcast_tx = nil
+        mock_arc_spy = Object.new
+        mock_arc_spy.define_singleton_method(:broadcast) do |tx, **|
+          broadcast_tx = tx
+          Struct.new(:txid, :tx_status).new("cc" * 32, "SEEN_ON_NETWORK")
+        end
+
+        spy_gateway = described_class.new(
+          arc_client: mock_arc_spy,
+          wallet: mock_wallet,
+          binding_mode: :permissive
+        )
+
+        # Build proof WITHOUT beef field
+        headers = spy_gateway.challenge_headers(mock_request, route)
+        challenge = JSON.parse(Base64.strict_decode64(headers["Payment-Required"]))
+        accepted = challenge["accepts"].first
+        payee_script = BSV::Script::Script.from_hex(accepted["payTo"])
+
+        tx = BSV::Transaction::Transaction.new
+        tx.add_output(BSV::Transaction::TransactionOutput.new(satoshis: 100, locking_script: payee_script))
+        tx.add_input(BSV::Transaction::TransactionInput.new(
+                       prev_tx_id: ["dd" * 32].pack("H*"),
+                       prev_tx_out_index: 0,
+                       unlocking_script: BSV::Script::Script.new("\x00".b)
+                     ))
+
+        payload = {
+          "x402Version" => 2,
+          "accepted" => accepted,
+          "payload" => {
+            "rawtx" => tx.to_binary.unpack1("H*"),
+            "txid" => tx.txid_hex
+          }
+        }
+        proof = Base64.strict_encode64(JSON.generate(payload))
+
+        spy_gateway.settle!("Payment-Signature", proof, mock_request, route)
+
+        expect(broadcast_tx).not_to be_nil
+        expect(broadcast_tx.txid_hex).to eq(tx.txid_hex)
+      end
+
       it "calls wallet.internalize_action after broadcast when wallet is present" do
         called = false
         mock_wallet.define_singleton_method(:internalize_action) do |_args = {}|


### PR DESCRIPTION
## Summary

`settle_transaction!` now extracts the subject transaction from the client's BEEF bundle (with ancestry wired via `find_atomic_transaction`) before broadcasting to ARC. This ensures ARC can validate inputs for `noSend` payments where parent UTXOs are only present in the BEEF.

Falls back to raw tx broadcast when no BEEF is present in the proof payload (backward compat).

### Root cause

`arc_client.broadcast(transaction)` sent the raw parsed transaction which lacks input ancestry. For `noSend: true` payments (bsv-x402), ARC needs the full BEEF to validate — returning 404 "Transaction not found".

Same pattern as BRC-121/BRC-105 gateways which already use `beef.find_atomic_transaction(txid)` before broadcasting.

## Test plan

- [x] 458 RSpec examples, 0 failures
- [x] RuboCop clean
- [x] New test: BEEF-extracted tx broadcast when beef present
- [x] New test: raw tx fallback when beef absent

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)