### PR TITLE
fix: add diagnostic context to all gateway error logging

### DIFF
--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -173,12 +173,19 @@ module X402
           @arc_client.broadcast(subject_tx, wait_for: route.arc_wait_for)
         end
       rescue ::BSV::Network::BroadcastError => e
+        txid = subject_tx.txid_hex
+        beef_type = beef.subject_txid ? "atomic" : "full"
         if e.status_code.is_a?(Integer) && e.status_code >= 500
+          logger.warn "[brc105] ARC outage: txid=#{txid} beef=#{beef_type} " \
+                      "status=#{e.status_code} message=#{e.message}"
           raise VerificationError.new("payment verification temporarily unavailable", status: 503)
         end
 
+        logger.info "[brc105] ARC rejected: txid=#{txid} beef=#{beef_type} " \
+                    "status=#{e.status_code.inspect} message=#{e.message}"
         raise VerificationError.new("payment not accepted: #{e.message}", status: 402)
-      rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH
+      rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH => e
+        logger.warn "[brc105] ARC network failure: txid=#{subject_tx.txid_hex} #{e.class}: #{e.message}"
         raise VerificationError.new("payment verification temporarily unavailable", status: 503)
       end
 
@@ -307,7 +314,8 @@ module X402
       rescue VerificationError
         raise
       rescue StandardError => e
-        logger.error "[brc105] internalize_action failed: #{e.class}: #{e.message}"
+        logger.error "[brc105] internalize_action failed: sender=#{sender_identity_key[0..15]}... " \
+                     "prefix=#{derivation_prefix} vout=#{output_index} #{e.class}: #{e.message}"
         raise VerificationError.new("payment internalisation failed", status: 402)
       end
 

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -290,22 +290,32 @@ module X402
           @arc_client.broadcast(subject_tx, wait_for: route.arc_wait_for)
         end
       rescue ::BSV::Network::BroadcastError => e
+        txid = subject_tx.txid_hex
+        beef_type = beef.subject_txid ? "atomic" : "full"
         if e.status_code.is_a?(Integer) && e.status_code >= 500
-          logger.warn "[brc121] ARC outage: #{e.message} (status=#{e.status_code})"
+          logger.warn "[brc121] ARC outage: txid=#{txid} beef=#{beef_type} " \
+                      "status=#{e.status_code} message=#{e.message}"
           raise VerificationError.new("payment verification temporarily unavailable", status: 503)
         end
 
-        logger.info "[brc121] ARC rejected: #{e.message} (status=#{e.status_code.inspect})"
+        logger.info "[brc121] ARC rejected: txid=#{txid} beef=#{beef_type} " \
+                    "status=#{e.status_code.inspect} message=#{e.message}"
         raise VerificationError.new("payment not accepted: #{e.message}", status: 402)
       rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH => e
-        logger.warn "[brc121] ARC network failure: #{e.class}: #{e.message}"
+        logger.warn "[brc121] ARC network failure: txid=#{subject_tx.txid_hex} #{e.class}: #{e.message}"
         raise VerificationError.new("payment verification temporarily unavailable", status: 503)
       end
 
       def verify_payment_output!(transaction, output_index, required_sats)
         output = transaction.outputs[output_index]
-        raise VerificationError.new("output index #{output_index} out of range", status: 400) unless output
+        unless output
+          logger.info "[brc121] Output index out of range: txid=#{transaction.txid_hex} " \
+                      "vout=#{output_index} num_outputs=#{transaction.outputs.length}"
+          raise VerificationError.new("output index #{output_index} out of range", status: 400)
+        end
         if output.satoshis < required_sats
+          logger.info "[brc121] Insufficient payment: txid=#{transaction.txid_hex} " \
+                      "vout=#{output_index} got=#{output.satoshis} required=#{required_sats}"
           raise VerificationError.new("insufficient payment: #{output.satoshis} < #{required_sats}",
                                       status: 402)
         end
@@ -334,7 +344,8 @@ module X402
         # Log the full error server-side; return a generic message to the
         # client to avoid leaking wallet internals (paths, key derivation
         # state, storage errors) in the HTTP response body.
-        logger.error "[brc121] internalize_action failed: #{e.class}: #{e.message}"
+        logger.error "[brc121] internalize_action failed: sender=#{sender_identity_key[0..15]}... " \
+                     "prefix=#{derivation_prefix} vout=#{output_index} #{e.class}: #{e.message}"
         raise VerificationError.new("payment internalisation failed", status: 402)
       end
 

--- a/lib/x402/bsv/pay_gateway.rb
+++ b/lib/x402/bsv/pay_gateway.rb
@@ -168,6 +168,9 @@ module X402
         end
         return if found
 
+        actual = transaction.outputs.map { |o| "#{o.satoshis} sats → #{o.locking_script.to_hex[0..15]}..." }
+        logger.info "[pay-gateway] Payment output mismatch: txid=#{transaction.txid_hex} " \
+                    "required=#{required_sats} payee=#{payee_hex[0..15]}... outputs=[#{actual.join(", ")}]"
         raise VerificationError.new("no output pays >= #{required_sats} sats to payee", status: 402)
       end
 
@@ -175,6 +178,7 @@ module X402
         return unless @txid_store
         return if @txid_store.record_if_unseen!(transaction.txid_hex)
 
+        logger.info "[pay-gateway] Duplicate txid rejected: #{transaction.txid_hex}"
         raise VerificationError.new("transaction already settled", status: 400)
       end
 
@@ -187,6 +191,8 @@ module X402
         return if found
         return if binding_mode == :permissive
 
+        logger.info "[pay-gateway] OP_RETURN binding mismatch: txid=#{transaction.txid_hex} " \
+                    "request=#{rack_request.request_method} #{rack_request.path_info}"
         raise VerificationError.new("OP_RETURN request binding mismatch", status: 400)
       end
 
@@ -216,7 +222,13 @@ module X402
         arc_client.broadcast(transaction, wait_for: wait_for)
       rescue VerificationError
         raise
-      rescue StandardError
+      rescue ::BSV::Network::BroadcastError => e
+        logger.warn "[pay-gateway] ARC rejected broadcast: txid=#{transaction.txid_hex} " \
+                    "status=#{e.status_code.inspect} message=#{e.message}"
+        raise VerificationError.new("ARC broadcast failed: #{e.message}", status: 502)
+      rescue StandardError => e
+        logger.error "[pay-gateway] ARC broadcast error: txid=#{transaction.txid_hex} " \
+                     "#{e.class}: #{e.message}"
         raise VerificationError.new("ARC broadcast failed", status: 502)
       end
 


### PR DESCRIPTION
## Summary

All error/failure paths across the three gateways now log diagnostic context (txid, parties, ARC responses) before raising VerificationError. Previously most failure paths raised with no server-side logging, making production issues hard to diagnose.

### PayGateway
- Payment output mismatch: txid, required sats, payee script, actual outputs
- Duplicate txid: the rejected txid
- OP_RETURN binding mismatch: txid, request method/path
- ARC broadcast failure: txid, ARC status code, error message (BroadcastError split from generic)

### BRC-121
- ARC rejection/outage: txid and BEEF type (atomic/full) added to existing logs
- ARC network failure: txid
- Output verification: txid, vout, got vs required
- internalize_action: sender key, derivation prefix, vout

### BRC-105
- ARC rejection/outage/network: txid and BEEF type (matching BRC-121 pattern)
- internalize_action: sender key, derivation prefix, vout

## Test plan

- [x] 458 RSpec examples, 0 failures
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)