### PR TITLE
fix!: remove vendor-broadcast from BRC-121 and BRC-105 gateways

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 x402-rack is a Ruby gem providing Rack middleware for the x402 protocol (BSV settlement-gated HTTP). Requires Ruby >= 3.1.
 
-The core invariant is **NO PAY → NO CONTENT**: content is served if and only if the vendor has successfully broadcast the payment transaction to the BSV network. `BRC121Gateway` and `BRC105Gateway` broadcast the client's signed BEEF to ARC themselves between output verification and `internalize_action` — ARC is idempotent, so a client that has already broadcast is fine. `ProofGateway` keeps its client-broadcasts-first, server-reads-status semantics (the scheme demands it). ARC is a hard runtime dependency; ARC rejections return 402, ARC outages return 503. There is no kill-switch — vendor-broadcast is not optional.
+The core invariant is **NO PAY → NO CONTENT**: content is served if and only if the payment transaction is confirmed on the BSV network via ARC.
+
+Each gateway implements its spec's settlement model:
+- **PayGateway** (our Coinbase v2 protocol): the server broadcasts via ARC. Vendor-broadcast is our design.
+- **BRC121Gateway** (BRC-121 spec): the client broadcasts. The server verifies via `arc_client.status(txid)`, then calls `internalizeAction`. `BroadcastError` = NO PAY.
+- **BRC105Gateway** (BRC-105 spec): the client broadcasts (§6.3). The server verifies via `arc_client.status(txid)`, then calls `internalizeAction`. `BroadcastError` = NO PAY.
+- **ProofGateway** (merkleworks): the client broadcasts. The server checks mempool status via ARC.
 
 ## Commands
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    x402-rack (0.11.1)
+    x402-rack (0.11.2)
       base64 (~> 0.2)
       bsv-sdk (>= 0.12.1, < 1.0)
       bsv-wallet (>= 0.9.1, < 1.0)

--- a/lib/x402/bsv/brc105_gateway.rb
+++ b/lib/x402/bsv/brc105_gateway.rb
@@ -6,18 +6,9 @@ require "base64"
 require "bsv-sdk"
 
 # NO PAY -> NO CONTENT: this gateway serves content if and only if the
-# vendor has verified that the payment transaction was accepted by ARC.
-# The invariant is enforced by +#settle_payment!+ (below), which runs
-# after payment output verification but BEFORE +consume_prefix!+ and
-# +internalize_action+ — the ordering matters for retry semantics.
-#
-# Settlement is BEEF-type-aware:
-# - Full BEEF (+subject_txid+ nil): the client has NOT broadcast — the
-#   vendor broadcasts via +arc.broadcast+.
-# - Atomic BEEF (+subject_txid+ set): the client signals it already
-#   broadcast — the vendor verifies via +arc.status+.
-#
-# See README "What x402-rack guarantees".
+# payment transaction is known to ARC. Per BRC-105 §6.3, the CLIENT
+# broadcasts. The server verifies via +arc_client.status(txid)+.
+# BroadcastError from status = NO PAY.
 
 module X402
   module BSV
@@ -43,13 +34,9 @@ module X402
       # @param key_deriver [BSV::Wallet::KeyDeriver] provides identity key + BRC-42 derivation
       # @param prefix_store [#store!, #valid?, #consume!] replay protection for derivation prefixes
       # @param wallet [#internalize_action] BRC-100 wallet for payment internalisation
-      # @param arc_client [#broadcast, #status, nil] ARC client used by the
-      #   gateway to settle the payment transaction (broadcast Full BEEF,
-      #   verify Atomic BEEF). Required at +settle!+ time — a nil
-      #   +arc_client+ silently breaks the NO PAY -> NO CONTENT invariant,
-      #   so we fail loudly instead. Construction still permits +nil+ for
-      #   unit-test ergonomics; production paths always wire ARC via
-      #   +Configuration#shared_arc_client+.
+      # @param arc_client [#status, nil] ARC client for verifying the tx
+      #   is on-chain before serving content (NO PAY -> NO CONTENT).
+      #   The client broadcasts; we just check status.
       def initialize(key_deriver:, prefix_store:, wallet:, arc_client: nil)
         @key_deriver = key_deriver
         @prefix_store = prefix_store
@@ -107,17 +94,15 @@ module X402
         prefix = payment["derivationPrefix"]
         suffix = payment["derivationSuffix"]
         validate_prefix_and_suffix!(prefix, suffix)
-        beef, subject_tx = parse_beef_transaction(payment["transaction"])
+        subject_tx = parse_beef_transaction(payment["transaction"])
         log_derivation_inputs(prefix, suffix, counterparty)
         expected_script = derive_payment_script(prefix, suffix, rack_request)
         log_expected_script(expected_script)
         log_tx_outputs(subject_tx, required_sats, expected_script)
         paid_sats, output_index = verify_payment_output!(subject_tx, required_sats, expected_script)
-        # Settle BEFORE consume_prefix! so a legitimate retry after a
-        # transient settlement failure can still use the prefix. Consuming
-        # first would make the subsequent attempt fail the replay check
-        # regardless of whether the client fixed their broadcast.
-        settle_payment!(beef, subject_tx, route)
+        # Verify BEFORE consume_prefix! so a transient ARC failure
+        # doesn't consume the prefix — the client can retry.
+        verify_on_chain!(subject_tx.txid_hex)
         consume_prefix!(prefix)
         internalize_payment!(
           transaction_b64: payment["transaction"],
@@ -132,60 +117,29 @@ module X402
 
       private
 
-      # Settle the payment via ARC. The vendor — not the client — is the
-      # settlement authority: a 2xx from ARC means the network accepted
-      # the tx. Structurally valid BEEF proves nothing about whether the
-      # client actually broadcast.
-      #
-      # Settlement is BEEF-type-aware:
-      # - Full BEEF (+subject_txid+ nil): client hasn't broadcast →
-      #   vendor broadcasts via +arc.broadcast+.
-      # - Atomic BEEF (+subject_txid+ set): client signals it already
-      #   broadcast → vendor verifies via +arc.status+.
-      #
-      # NOTE: if ARC hasn't seen the tx yet on the Atomic path
-      # (propagation lag from a just-broadcast client), status raises
-      # BroadcastError. In practice this hasn't been observed as an
-      # issue. If it becomes one, add a bounded retry here — but
-      # observe first, don't pre-build.
-      #
-      # A nil +@arc_client+ silently breaks the NO PAY -> NO CONTENT
-      # invariant, so we raise a configuration error instead of quietly
-      # skipping. Production paths always wire ARC via
-      # +Configuration#shared_arc_client+.
-      #
-      # Error mapping mirrors BRC-121:
-      # - +BroadcastError+ with +status_code >= 500+   → 503 (ARC outage)
-      # - +BroadcastError+ otherwise                    → 402 (client's tx rejected)
-      # - Network errors (+SocketError+, +Timeout+, +Errno::*+) → 503
-      def settle_payment!(beef, subject_tx, route)
+      # NO PAY -> NO CONTENT: verify the tx is known to ARC before
+      # serving content. The client broadcasts (§6.3); we check status.
+      # BroadcastError = tx not on-chain = 402.
+      # ARC 5xx / network errors = 503.
+      def verify_on_chain!(txid)
         unless @arc_client
           raise VerificationError.new(
-            "gateway misconfigured: arc_client is required for payment settlement", status: 500
+            "gateway misconfigured: arc_client is required for payment verification", status: 500
           )
         end
 
-        if beef.subject_txid
-          # Atomic BEEF: client signals they already broadcast → verify via GET.
-          @arc_client.status(subject_tx.txid_hex)
-        else
-          # Full BEEF: client wants us to broadcast → POST.
-          @arc_client.broadcast(subject_tx, wait_for: route.arc_wait_for)
-        end
+        @arc_client.status(txid)
       rescue ::BSV::Network::BroadcastError => e
-        txid = subject_tx.txid_hex
-        beef_type = beef.subject_txid ? "atomic" : "full"
         if e.status_code.is_a?(Integer) && e.status_code >= 500
-          logger.warn "[brc105] ARC outage: txid=#{txid} beef=#{beef_type} " \
-                      "status=#{e.status_code} message=#{e.message}"
+          logger.warn "[brc105] ARC outage: txid=#{txid} status=#{e.status_code} message=#{e.message}"
           raise VerificationError.new("payment verification temporarily unavailable", status: 503)
         end
 
-        logger.info "[brc105] ARC rejected: txid=#{txid} beef=#{beef_type} " \
+        logger.info "[brc105] ARC status check failed: txid=#{txid} " \
                     "status=#{e.status_code.inspect} message=#{e.message}"
         raise VerificationError.new("payment not accepted: #{e.message}", status: 402)
       rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH => e
-        logger.warn "[brc105] ARC network failure: txid=#{subject_tx.txid_hex} #{e.class}: #{e.message}"
+        logger.warn "[brc105] ARC network failure: txid=#{txid} #{e.class}: #{e.message}"
         raise VerificationError.new("payment verification temporarily unavailable", status: 503)
       end
 
@@ -232,20 +186,13 @@ module X402
         raw = Base64.strict_decode64(transaction_b64)
         beef = ::BSV::Transaction::Beef.from_binary(raw)
 
-        # Atomic BEEF embeds a subject_txid; Full BEEF does not — derive
-        # it from the last raw transaction in the bundle (dependency order
-        # puts the subject last).
         txid = beef.subject_txid || beef.transactions.reverse_each.find(&:transaction)&.txid
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless txid
 
-        # find_atomic_transaction wires ancestry (source_transaction on each
-        # input). Required so arc.broadcast(subject_tx) can emit EF —
-        # otherwise we fall back to raw hex and ARC rejects broadcasts whose
-        # parents are unconfirmed and only present in the BEEF. See #177.
-        subject_tx = beef.find_atomic_transaction(txid)
+        subject_tx = beef.find_transaction(txid)
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless subject_tx
 
-        [beef, subject_tx]
+        subject_tx
       rescue ArgumentError
         raise VerificationError.new("invalid base64 in transaction", status: 400)
       rescue VerificationError

--- a/lib/x402/bsv/brc121_gateway.rb
+++ b/lib/x402/bsv/brc121_gateway.rb
@@ -5,19 +5,10 @@ require "bsv-sdk"
 require_relative "txid_store"
 
 # NO PAY -> NO CONTENT: this gateway serves content if and only if the
-# vendor has verified that the payment transaction was accepted by ARC.
-# The invariant is enforced by +#settle_payment!+ (below), which is
-# called between output verification and +internalize_action+ so wallet
-# state is never mutated for a transaction ARC refused.
-#
-# Settlement is BEEF-type-aware:
-# - Full BEEF (+subject_txid+ nil): the client has NOT broadcast — the
-#   vendor broadcasts via +arc.broadcast+.
-# - Atomic BEEF (+subject_txid+ set): the client signals it already
-#   broadcast — the vendor verifies via +arc.status+.
-#
-# ARC's idempotency guarantees duplicate broadcasts of an already-seen
-# tx are safe. See README "What x402-rack guarantees".
+# payment transaction is known to ARC (i.e. on-chain or accepted by the
+# network). Per BRC-121, the CLIENT broadcasts. The server verifies via
+# +arc_client.status(txid)+ before calling +internalizeAction+.
+# BroadcastError from status = NO PAY.
 
 module X402
   module BSV
@@ -80,13 +71,10 @@ module X402
       #   +#get_public_key(identity_key: true)+ for the server identity key.
       # @param txid_store [#record_if_unseen!, nil] replay protection for
       #   settled txids. Defaults to +X402::BSV::TxidStore::Memory.new+.
-      # @param arc_client [#broadcast, #status] ARC client used by the
-      #   vendor to settle the payment transaction (broadcast Full BEEF,
-      #   verify Atomic BEEF) before the wallet internalises it. Required
-      #   at +#settle!+ time — a nil arc_client silently breaks the
-      #   NO PAY -> NO CONTENT invariant, so we fail loudly instead.
-      #   Production wiring via +Configuration+ always supplies one;
-      #   direct-construction unit tests must inject a double.
+      # @param arc_client [#status] ARC client for verifying the tx is
+      #   on-chain before serving content (NO PAY -> NO CONTENT). The
+      #   client broadcasts; we just check status. Required at +#settle!+
+      #   time — a nil arc_client silently breaks the invariant.
       def initialize(wallet:, txid_store: nil, arc_client: nil)
         @wallet = wallet
         @txid_store = txid_store || TxidStore::Memory.new
@@ -129,16 +117,16 @@ module X402
         validate_nonce!(headers["x-bsv-nonce"])
         validate_timestamp_freshness!(headers["x-bsv-time"])
         output_index = parse_output_index!(headers["x-bsv-vout"])
-        beef, subject_tx = parse_beef_transaction(headers["x-bsv-beef"])
+        subject_tx = parse_beef_transaction(headers["x-bsv-beef"])
 
         paid_sats = verify_payment_output!(subject_tx, output_index, required_sats)
 
-        settle_payment!(beef, subject_tx, route)
+        # NO PAY -> NO CONTENT: verify the tx is known to ARC before
+        # mutating wallet state. BroadcastError = not on-chain = 402.
+        verify_on_chain!(subject_tx.txid_hex)
 
-        # Replay guard AFTER settle_payment! so a transient ARC failure
-        # (503, timeout, propagation lag on the Atomic BEEF status path)
-        # doesn't consume the txid — the client can retry with the same
-        # transaction. Mirrors BRC105Gateway's consume-after-settle ordering.
+        # Replay guard AFTER verify_on_chain! so a transient ARC failure
+        # doesn't consume the txid — the client can retry.
         check_txid_unique!(subject_tx.txid_hex)
 
         result = internalize_payment!(
@@ -229,20 +217,13 @@ module X402
         raw = Base64.strict_decode64(transaction_b64)
         beef = ::BSV::Transaction::Beef.from_binary(raw)
 
-        # Atomic BEEF embeds a subject_txid; Full BEEF does not — derive
-        # it from the last raw transaction in the bundle (dependency order
-        # puts the subject last).
         txid = beef.subject_txid || beef.transactions.reverse_each.find(&:transaction)&.txid
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless txid
 
-        # find_atomic_transaction wires ancestry (source_transaction on each
-        # input). Required so arc.broadcast(subject_tx) can emit EF —
-        # otherwise we fall back to raw hex and ARC rejects broadcasts whose
-        # parents are unconfirmed and only present in the BEEF. See #177.
-        subject_tx = beef.find_atomic_transaction(txid)
+        subject_tx = beef.find_transaction(txid)
         raise VerificationError.new("no subject transaction in BEEF bundle", status: 400) unless subject_tx
 
-        [beef, subject_tx]
+        subject_tx
       rescue ArgumentError
         raise VerificationError.new("invalid base64 in x-bsv-beef", status: 400)
       rescue VerificationError
@@ -257,52 +238,28 @@ module X402
         raise VerificationError.new("replay: transaction already settled", status: 402)
       end
 
-      # Settle the payment via ARC before we mutate wallet state. The
-      # vendor is the settlement authority: a 2xx from ARC means the
-      # network has accepted the transaction.
-      #
-      # Settlement is BEEF-type-aware:
-      # - Full BEEF (+subject_txid+ nil): client hasn't broadcast →
-      #   vendor broadcasts via +arc.broadcast+.
-      # - Atomic BEEF (+subject_txid+ set): client signals it already
-      #   broadcast → vendor verifies via +arc.status+.
-      #
-      # NOTE: if ARC hasn't seen the tx yet on the Atomic path
-      # (propagation lag from a just-broadcast client), status raises
-      # BroadcastError. In practice this hasn't been observed as an
-      # issue. If it becomes one, add a bounded retry here — but
-      # observe first, don't pre-build.
-      #
-      # Raising here (VerificationError 402 on rejection, 503 on ARC
-      # outage) keeps the exploit path from ever reaching
-      # +internalize_action+.
-      def settle_payment!(beef, subject_tx, route)
+      # NO PAY -> NO CONTENT: verify the tx is known to ARC before
+      # serving content. The client broadcasts; we just check status.
+      # BroadcastError = tx not on-chain = 402.
+      # ARC 5xx / network errors = 503.
+      def verify_on_chain!(txid)
         unless @arc_client
           logger.error "[brc121] arc_client is not configured"
-          raise VerificationError.new("arc_client is required for payment settlement", status: 500)
+          raise VerificationError.new("arc_client is required for payment verification", status: 500)
         end
 
-        if beef.subject_txid
-          # Atomic BEEF: client signals they already broadcast → verify via GET.
-          @arc_client.status(subject_tx.txid_hex)
-        else
-          # Full BEEF: client wants us to broadcast → POST.
-          @arc_client.broadcast(subject_tx, wait_for: route.arc_wait_for)
-        end
+        @arc_client.status(txid)
       rescue ::BSV::Network::BroadcastError => e
-        txid = subject_tx.txid_hex
-        beef_type = beef.subject_txid ? "atomic" : "full"
         if e.status_code.is_a?(Integer) && e.status_code >= 500
-          logger.warn "[brc121] ARC outage: txid=#{txid} beef=#{beef_type} " \
-                      "status=#{e.status_code} message=#{e.message}"
+          logger.warn "[brc121] ARC outage: txid=#{txid} status=#{e.status_code} message=#{e.message}"
           raise VerificationError.new("payment verification temporarily unavailable", status: 503)
         end
 
-        logger.info "[brc121] ARC rejected: txid=#{txid} beef=#{beef_type} " \
+        logger.info "[brc121] ARC status check failed: txid=#{txid} " \
                     "status=#{e.status_code.inspect} message=#{e.message}"
         raise VerificationError.new("payment not accepted: #{e.message}", status: 402)
       rescue SocketError, Timeout::Error, Errno::ECONNREFUSED, Errno::ETIMEDOUT, Errno::EHOSTUNREACH => e
-        logger.warn "[brc121] ARC network failure: txid=#{subject_tx.txid_hex} #{e.class}: #{e.message}"
+        logger.warn "[brc121] ARC network failure: txid=#{txid} #{e.class}: #{e.message}"
         raise VerificationError.new("payment verification temporarily unavailable", status: 503)
       end
 

--- a/spec/x402/bsv/brc105_gateway_spec.rb
+++ b/spec/x402/bsv/brc105_gateway_spec.rb
@@ -189,14 +189,6 @@ RSpec.describe X402::BSV::BRC105Gateway do
       Base64.strict_encode64(atomic_binary)
     end
 
-    # Full BEEF: subject_txid nil → settle_payment! calls arc.broadcast
-    def build_full_beef_b64(transaction)
-      beef = BSV::Transaction::Beef.new
-      beef.merge_transaction(transaction)
-      Base64.strict_encode64(beef.to_binary)
-    end
-
-    # Default proof payload uses Atomic BEEF (existing behaviour)
     def build_proof_payload(prefix:, suffix:, transaction:)
       JSON.generate({
                       "derivationPrefix" => prefix,
@@ -205,24 +197,11 @@ RSpec.describe X402::BSV::BRC105Gateway do
                     })
     end
 
-    # Full BEEF proof payload for vendor-broadcast specs
-    def build_full_beef_proof_payload(prefix:, suffix:, transaction:)
-      JSON.generate({
-                      "derivationPrefix" => prefix,
-                      "derivationSuffix" => suffix,
-                      "transaction" => build_full_beef_b64(transaction)
-                    })
-    end
-
     before do
       prefix_store.store!(prefix)
       allow(wallet).to receive(:internalize_action).and_return({ accepted: true })
-      # Default: ARC accepts both broadcast and status. The default fixture
-      # is Atomic BEEF, so +status+ is the primary path; +broadcast+ is
-      # stubbed for Full BEEF specs. Individual contexts override these to
-      # drive rejection / outage / network-error paths.
+      # Default: ARC confirms the tx is on-chain. Status-only — no broadcast.
       allow(arc_client).to receive(:status).and_return(instance_double(BSV::Network::BroadcastResponse))
-      allow(arc_client).to receive(:broadcast).and_return(instance_double(BSV::Network::BroadcastResponse))
     end
 
     # §6.4 step 2: "Ensuring the output script pays to the correct derivation"
@@ -413,215 +392,85 @@ RSpec.describe X402::BSV::BRC105Gateway do
       end
     end
 
-    # BEEF-type-aware settlement (#180): the vendor settles the payment
-    # via ARC between output verification and +consume_prefix!+.
-    # Full BEEF (no subject_txid) → arc.broadcast; Atomic BEEF
-    # (subject_txid set) → arc.status. Settlement runs BEFORE
-    # consume_prefix! and internalize_action.
-    context "vendor settlement (#180)" do
-      # --- Full BEEF (vendor broadcasts) ---
-      context "Full BEEF (vendor broadcasts)" do
-        it "calls arc_client.broadcast with subject tx and route's wait_for" do
-          waiting_route = X402::Configuration::Route.new(
-            http_method: "GET", path: "/premium", amount_sats: 1000, arc_wait_for: "SEEN_ON_NETWORK"
-          )
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+    # NO PAY -> NO CONTENT: verify the tx is on-chain via ARC status
+    # before consuming prefix or calling internalizeAction.
+    # Client broadcasts (BRC-105 §6.3); we just check status.
+    context "on-chain verification (NO PAY -> NO CONTENT)" do
+      it "calls arc_client.status with the subject txid" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
 
-          real_gateway.settle!("x-bsv-payment", payload, request, waiting_route)
+        real_gateway.settle!("x-bsv-payment", payload, request, route)
 
-          expect(arc_client).to have_received(:broadcast)
-            .with(an_instance_of(BSV::Transaction::Transaction), wait_for: "SEEN_ON_NETWORK")
-        end
-
-        it "settles successfully, consumes the prefix, and calls internalize_action" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-
-          result = real_gateway.settle!("x-bsv-payment", payload, request, route)
-
-          expect(result).to be_a(X402::SettlementResult)
-          expect(prefix_store.valid?(prefix)).to be false
-          expect(wallet).to have_received(:internalize_action)
-        end
-
-        it "does NOT call arc_client.status" do
-          allow(arc_client).to receive(:status)
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-
-          real_gateway.settle!("x-bsv-payment", payload, request, route)
-
-          expect(arc_client).not_to have_received(:status)
-        end
-
-        it "raises VerificationError(402) when ARC rejects the broadcast" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast)
-            .and_raise(BSV::Network::BroadcastError.new("malformed tx", status_code: 400))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /payment not accepted/) { |e| expect(e.status).to eq(402) }
-        end
-
-        it "raises VerificationError(402) when ARC rejects with no status_code" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast).and_raise(BSV::Network::BroadcastError.new("unknown"))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /payment not accepted/) { |e| expect(e.status).to eq(402) }
-        end
-
-        it "raises VerificationError(503) when ARC returns a 5xx" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast)
-            .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
-        end
-
-        it "raises VerificationError(503) on network error" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast).and_raise(SocketError.new("network down"))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
-        end
-
-        # Critical for retry semantics: settlement runs BEFORE consume_prefix!,
-        # so a transient failure must leave the prefix available for a
-        # legitimate retry.
-        it "does NOT consume the prefix when broadcast fails" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast).and_raise(BSV::Network::BroadcastError.new("unknown"))
-          allow(prefix_store).to receive(:consume!).and_call_original
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(prefix_store).not_to have_received(:consume!)
-          expect(prefix_store.valid?(prefix)).to be true
-        end
-
-        it "does NOT call wallet.internalize_action when broadcast fails" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_full_beef_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:broadcast).and_raise(BSV::Network::BroadcastError.new("unknown"))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(wallet).not_to have_received(:internalize_action)
-        end
+        expect(arc_client).to have_received(:status).with(transaction.txid_hex)
       end
 
-      # --- Atomic BEEF (vendor verifies) ---
-      context "Atomic BEEF (vendor verifies)" do
-        it "calls arc_client.status with the subject txid" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+      it "settles successfully, consumes the prefix, and calls internalize_action" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
 
-          real_gateway.settle!("x-bsv-payment", payload, request, route)
+        result = real_gateway.settle!("x-bsv-payment", payload, request, route)
 
-          expect(arc_client).to have_received(:status).with(transaction.txid_hex)
-        end
-
-        it "settles successfully, consumes the prefix, and calls internalize_action" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-
-          result = real_gateway.settle!("x-bsv-payment", payload, request, route)
-
-          expect(result).to be_a(X402::SettlementResult)
-          expect(prefix_store.valid?(prefix)).to be false
-          expect(wallet).to have_received(:internalize_action)
-        end
-
-        it "does NOT call arc_client.broadcast" do
-          allow(arc_client).to receive(:broadcast)
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-
-          real_gateway.settle!("x-bsv-payment", payload, request, route)
-
-          expect(arc_client).not_to have_received(:broadcast)
-        end
-
-        it "does NOT pass wait_for (status takes txid only)" do
-          waiting_route = X402::Configuration::Route.new(
-            http_method: "GET", path: "/premium", amount_sats: 1000, arc_wait_for: "SEEN_ON_NETWORK"
-          )
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-
-          real_gateway.settle!("x-bsv-payment", payload, request, waiting_route)
-
-          expect(arc_client).to have_received(:status).with(transaction.txid_hex)
-        end
-
-        it "raises VerificationError(402) when ARC rejects the status check" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /payment not accepted/) { |e| expect(e.status).to eq(402) }
-        end
-
-        it "does NOT call wallet.internalize_action when status check is rejected" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(wallet).not_to have_received(:internalize_action)
-        end
-
-        it "does NOT consume the prefix when status check fails" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
-          allow(prefix_store).to receive(:consume!).and_call_original
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(prefix_store).not_to have_received(:consume!)
-          expect(prefix_store.valid?(prefix)).to be true
-        end
-
-        it "raises VerificationError(503) when ARC returns a 5xx" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
-        end
-
-        it "raises VerificationError(503) on network error" do
-          transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
-          payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
-          allow(arc_client).to receive(:status).and_raise(SocketError.new("dns fail"))
-
-          expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
-            .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
-        end
+        expect(result).to be_a(X402::SettlementResult)
+        expect(prefix_store.valid?(prefix)).to be false
+        expect(wallet).to have_received(:internalize_action)
       end
 
-      # --- arc_client nil ---
+      it "raises VerificationError(402) when tx is not on-chain" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /payment not accepted/) { |e| expect(e.status).to eq(402) }
+      end
+
+      it "does NOT consume the prefix when verification fails" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
+        allow(prefix_store).to receive(:consume!).and_call_original
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError)
+
+        expect(prefix_store).not_to have_received(:consume!)
+        expect(prefix_store.valid?(prefix)).to be true
+      end
+
+      it "does NOT call wallet.internalize_action when verification fails" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError)
+
+        expect(wallet).not_to have_received(:internalize_action)
+      end
+
+      it "raises VerificationError(503) when ARC returns a 5xx" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
+      end
+
+      it "raises VerificationError(503) on network error" do
+        transaction = build_payment_tx(amount: 1000, script_hex: payment_script_hex)
+        payload = build_proof_payload(prefix: prefix, suffix: suffix, transaction: transaction)
+        allow(arc_client).to receive(:status).and_raise(SocketError.new("dns fail"))
+
+        expect { real_gateway.settle!("x-bsv-payment", payload, request, route) }
+          .to raise_error(X402::VerificationError, /temporarily unavailable/) { |e| expect(e.status).to eq(503) }
+      end
+
       context "when arc_client is nil" do
         it "raises a configuration error" do
           gateway_without_arc = described_class.new(

--- a/spec/x402/bsv/brc121_gateway_spec.rb
+++ b/spec/x402/bsv/brc121_gateway_spec.rb
@@ -20,15 +20,10 @@ RSpec.describe X402::BSV::BRC121Gateway do
   end
 
   let(:txid_store) { X402::BSV::TxidStore::Memory.new }
-  # Default arc_client is a permissive double so happy-path tests across
-  # the file don't have to stub ARC themselves. The default fixture is
-  # Atomic BEEF (subject_txid set), so we stub +status+ as the primary
-  # path; +broadcast+ is stubbed too for Full BEEF specs. Specs that
-  # exercise settlement specifically override this via an inner +let+.
+  # Default arc_client — status-only (client broadcasts, we verify).
   let(:arc_client) do
     ac = instance_double(BSV::Network::ARC)
     allow(ac).to receive(:status).and_return(Struct.new(:txid, :tx_status).new("a" * 64, "SEEN_ON_NETWORK"))
-    allow(ac).to receive(:broadcast).and_return(Struct.new(:txid, :tx_status).new("a" * 64, "SEEN_ON_NETWORK"))
     ac
   end
   let(:gateway) { described_class.new(wallet: wallet, txid_store: txid_store, arc_client: arc_client) }
@@ -54,18 +49,10 @@ RSpec.describe X402::BSV::BRC121Gateway do
     tx
   end
 
-  # Atomic BEEF: subject_txid is set → settle_payment! calls arc.status
   def build_beef_b64(transaction)
     beef = BSV::Transaction::Beef.new
     beef.merge_transaction(transaction)
     Base64.strict_encode64(beef.to_atomic_binary(transaction.txid))
-  end
-
-  # Full BEEF: subject_txid is nil → settle_payment! calls arc.broadcast
-  def build_full_beef_b64(transaction)
-    beef = BSV::Transaction::Beef.new
-    beef.merge_transaction(transaction)
-    Base64.strict_encode64(beef.to_binary)
   end
 
   def paid_request_env(beef_b64:, sender: client_identity_key, nonce: Base64.strict_encode64(SecureRandom.hex(16)),
@@ -407,197 +394,70 @@ RSpec.describe X402::BSV::BRC121Gateway do
       end
     end
 
-    # BEEF-type-aware settlement (#180): the vendor settles the payment
-    # via ARC between output verification and +internalize_action+.
-    # Full BEEF (no subject_txid) → arc.broadcast; Atomic BEEF
-    # (subject_txid set) → arc.status. Raising here keeps the exploit
-    # path from ever reaching the wallet.
-    context "vendor settlement (#180)" do
+    # NO PAY -> NO CONTENT: verify the tx is on-chain via ARC status
+    # before calling internalizeAction. Client broadcasts (per BRC-121 spec);
+    # we just check status. BroadcastError = NO PAY.
+    context "on-chain verification (NO PAY -> NO CONTENT)" do
       let(:arc_client) { instance_double(BSV::Network::ARC) }
       let(:gateway) { described_class.new(wallet: wallet, txid_store: txid_store, arc_client: arc_client) }
 
-      def arc_response(tx_status, txid: "a" * 64)
-        Struct.new(:txid, :tx_status).new(txid, tx_status)
+      it "calls arc_client.status with the subject txid" do
+        allow(arc_client).to receive(:status)
+          .and_return(Struct.new(:txid, :tx_status).new("a" * 64, "SEEN_ON_NETWORK"))
+        env = paid_request_env(beef_b64: beef_b64)
+
+        gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
+
+        expect(arc_client).to have_received(:status).with(transaction.txid_hex)
       end
 
-      # --- Full BEEF (vendor broadcasts) ---
-      context "Full BEEF (vendor broadcasts)" do
-        let(:full_beef_b64) { build_full_beef_b64(transaction) }
+      it "settles successfully and calls internalize_action" do
+        allow(arc_client).to receive(:status)
+          .and_return(Struct.new(:txid, :tx_status).new("a" * 64, "SEEN_ON_NETWORK"))
+        env = paid_request_env(beef_b64: beef_b64)
 
-        it "calls arc_client.broadcast with the subject tx and route's wait_for" do
-          route_with_wait = X402::Configuration::Route.new(
-            http_method: "GET", path: "/premium", amount_sats: 1000, arc_wait_for: "SEEN_ON_NETWORK"
-          )
-          allow(arc_client).to receive(:broadcast).and_return(arc_response("SEEN_ON_NETWORK"))
+        result = gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
 
-          env = paid_request_env(beef_b64: full_beef_b64)
-          gateway.settle!("x-bsv-beef", nil, mock_request(env), route_with_wait)
-
-          expect(arc_client).to have_received(:broadcast).with(
-            kind_of(BSV::Transaction::Transaction),
-            wait_for: "SEEN_ON_NETWORK"
-          )
-        end
-
-        it "settles successfully and calls internalize_action" do
-          allow(arc_client).to receive(:broadcast).and_return(arc_response("SEEN_ON_NETWORK"))
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          result = gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
-
-          expect(result).to be_a(X402::SettlementResult)
-          expect(wallet).to have_received(:internalize_action)
-        end
-
-        it "does NOT call arc_client.status" do
-          allow(arc_client).to receive(:broadcast).and_return(arc_response("SEEN_ON_NETWORK"))
-          allow(arc_client).to receive(:status)
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
-
-          expect(arc_client).not_to have_received(:status)
-        end
-
-        it "raises VerificationError(402) when ARC rejects the broadcast" do
-          allow(arc_client).to receive(:broadcast)
-            .and_raise(BSV::Network::BroadcastError.new("double-spend detected", status_code: 400))
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(402)
-              expect(e.reason).to match(/payment not accepted/i)
-              expect(e.reason).to include("double-spend detected")
-            }
-        end
-
-        it "does NOT call wallet.internalize_action when broadcast is rejected" do
-          allow(arc_client).to receive(:broadcast)
-            .and_raise(BSV::Network::BroadcastError.new("tx invalid", status_code: 400))
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(wallet).not_to have_received(:internalize_action)
-        end
-
-        it "raises VerificationError(503) when ARC returns a 5xx" do
-          allow(arc_client).to receive(:broadcast)
-            .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(503)
-              expect(e.reason).to match(/payment verification temporarily unavailable/i)
-            }
-        end
-
-        it "raises VerificationError(503) on network error" do
-          allow(arc_client).to receive(:broadcast).and_raise(SocketError, "getaddrinfo: nodename nor servname provided")
-          env = paid_request_env(beef_b64: full_beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(503)
-              expect(e.reason).to match(/payment verification temporarily unavailable/i)
-            }
-        end
+        expect(result).to be_a(X402::SettlementResult)
+        expect(wallet).to have_received(:internalize_action)
       end
 
-      # --- Atomic BEEF (vendor verifies) ---
-      context "Atomic BEEF (vendor verifies)" do
-        it "calls arc_client.status with the subject txid" do
-          allow(arc_client).to receive(:status).and_return(arc_response("SEEN_ON_NETWORK"))
-          env = paid_request_env(beef_b64: beef_b64)
+      it "raises VerificationError(402) when tx is not on-chain" do
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
+        env = paid_request_env(beef_b64: beef_b64)
 
-          gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
-
-          expect(arc_client).to have_received(:status).with(transaction.txid_hex)
-        end
-
-        it "settles successfully and calls internalize_action" do
-          allow(arc_client).to receive(:status).and_return(arc_response("SEEN_ON_NETWORK"))
-          env = paid_request_env(beef_b64: beef_b64)
-
-          result = gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
-
-          expect(result).to be_a(X402::SettlementResult)
-          expect(wallet).to have_received(:internalize_action)
-        end
-
-        it "does NOT call arc_client.broadcast" do
-          allow(arc_client).to receive(:status).and_return(arc_response("SEEN_ON_NETWORK"))
-          allow(arc_client).to receive(:broadcast)
-          env = paid_request_env(beef_b64: beef_b64)
-
-          gateway.settle!("x-bsv-beef", nil, mock_request(env), route)
-
-          expect(arc_client).not_to have_received(:broadcast)
-        end
-
-        it "does NOT pass wait_for (status takes txid only)" do
-          allow(arc_client).to receive(:status).and_return(arc_response("SEEN_ON_NETWORK"))
-          route_with_wait = X402::Configuration::Route.new(
-            http_method: "GET", path: "/premium", amount_sats: 1000, arc_wait_for: "SEEN_ON_NETWORK"
-          )
-          env = paid_request_env(beef_b64: beef_b64)
-
-          gateway.settle!("x-bsv-beef", nil, mock_request(env), route_with_wait)
-
-          expect(arc_client).to have_received(:status).with(transaction.txid_hex)
-        end
-
-        it "raises VerificationError(402) when ARC rejects the status check" do
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
-          env = paid_request_env(beef_b64: beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(402)
-              expect(e.reason).to match(/payment not accepted/i)
-            }
-        end
-
-        it "does NOT call wallet.internalize_action when status check is rejected" do
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
-          env = paid_request_env(beef_b64: beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError)
-
-          expect(wallet).not_to have_received(:internalize_action)
-        end
-
-        it "raises VerificationError(503) when ARC returns a 5xx" do
-          allow(arc_client).to receive(:status)
-            .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
-          env = paid_request_env(beef_b64: beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(503)
-              expect(e.reason).to match(/payment verification temporarily unavailable/i)
-            }
-        end
-
-        it "raises VerificationError(503) on network error" do
-          allow(arc_client).to receive(:status).and_raise(SocketError, "dns fail")
-          env = paid_request_env(beef_b64: beef_b64)
-
-          expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
-            .to raise_error(X402::VerificationError) { |e|
-              expect(e.status).to eq(503)
-              expect(e.reason).to match(/payment verification temporarily unavailable/i)
-            }
-        end
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e| expect(e.status).to eq(402) }
       end
 
-      # --- arc_client nil (either BEEF type) ---
+      it "does NOT call wallet.internalize_action when tx is not on-chain" do
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("tx not found", status_code: 404))
+        env = paid_request_env(beef_b64: beef_b64)
+
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError)
+        expect(wallet).not_to have_received(:internalize_action)
+      end
+
+      it "raises VerificationError(503) when ARC returns a 5xx" do
+        allow(arc_client).to receive(:status)
+          .and_raise(BSV::Network::BroadcastError.new("boom", status_code: 500))
+        env = paid_request_env(beef_b64: beef_b64)
+
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e| expect(e.status).to eq(503) }
+      end
+
+      it "raises VerificationError(503) on network error" do
+        allow(arc_client).to receive(:status).and_raise(SocketError, "dns fail")
+        env = paid_request_env(beef_b64: beef_b64)
+
+        expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
+          .to raise_error(X402::VerificationError) { |e| expect(e.status).to eq(503) }
+      end
+
       context "when arc_client is nil" do
         let(:gateway) { described_class.new(wallet: wallet, txid_store: txid_store, arc_client: nil) }
 
@@ -616,7 +476,6 @@ RSpec.describe X402::BSV::BRC121Gateway do
 
           expect { gateway.settle!("x-bsv-beef", nil, mock_request(env), route) }
             .to raise_error(X402::VerificationError)
-
           expect(wallet).not_to have_received(:internalize_action)
         end
       end


### PR DESCRIPTION
## Summary

Per BRC-121 §5 and BRC-105 §6.3, the **client** broadcasts. The server's job is to verify the tx is on-chain before serving content.

`settle_payment!` (which broadcast Full BEEF and verified Atomic BEEF) is replaced by `verify_on_chain!` — a single `arc_client.status(txid)` call. `BroadcastResponse` = on-chain = serve content. `BroadcastError` = NO PAY.

### What changed

- `settle_payment!` → `verify_on_chain!(txid)` — status-only, no broadcast, no BEEF-type branching
- `parse_beef_transaction` returns `subject_tx` only (no `[beef, subject_tx]` tuple)
- `find_atomic_transaction` removed (only needed for broadcast ancestry wiring)
- `arc_client` stays — needed for `#status`, not `#broadcast`
- Constructor signature unchanged (`arc_client:` kwarg preserved)
- Configuration still auto-injects `shared_arc_client`

### Invariant preserved

**NO PAY → NO CONTENT** — `verify_on_chain!` runs before `internalizeAction` and `consume_prefix!`. ARC rejection (402), ARC outage (503), network error (503) all block the 200.

### What was removed

- All `arc_client.broadcast` calls from BRC-121 and BRC-105
- BEEF-type detection (Full vs Atomic branching)
- `find_atomic_transaction` ancestry wiring
- `build_full_beef_b64` test helpers
- 20 broadcast-specific specs (replaced with status-only equivalents)

### PayGateway

Untouched. PayGateway broadcasts — that's our protocol, our rules.

## Test plan

- [x] 438 RSpec examples, 0 failures
- [x] RuboCop clean
- [x] `verify_on_chain!` tested: status success, 402 on BroadcastError, 503 on ARC 5xx, 503 on network error, 500 on nil arc_client
- [x] CLAUDE.md updated

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)